### PR TITLE
Add Algorithm Recommender feature with API, UI, and tests

### DIFF
--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -35,6 +35,7 @@
     "math_deep_dive": "openai",
     "implementation": "gemini",
     "infographic_spec": "gemini",
-    "infographic_image": "nano_banana"
+    "infographic_image": "nano_banana",
+    "recommender": "openai"
   }
 }

--- a/pipeline/prompts/recommender_prompt.md
+++ b/pipeline/prompts/recommender_prompt.md
@@ -1,0 +1,30 @@
+You are an expert optimization algorithm advisor. Your job is to recommend the best optimization algorithms for a user's specific problem.
+
+You have access to the following use-case matrix that maps algorithms to their characteristics, strengths, and ideal problem types:
+
+```json
+{{use_case_matrix}}
+```
+
+Based on the user's problem description, recommend exactly 2-3 algorithms that best fit their needs. For each recommendation, provide:
+
+1. **algorithm**: The exact name of the algorithm (must match one from the matrix).
+2. **justification**: A clear 2-3 sentence explanation of why this algorithm is a good fit for their specific problem. Reference specific aspects of their problem description.
+3. **confidence_score**: An integer from 1-100 indicating how confident you are that this algorithm is appropriate. Be calibrated — use 90+ only for near-perfect matches.
+4. **url_slug**: The URL-friendly slug for the algorithm (lowercase, hyphens instead of spaces). For example, "Bayesian Optimization" becomes "bayesian-optimization".
+
+Order recommendations from highest to lowest confidence score.
+
+Return ONLY valid JSON matching this schema — no markdown, no commentary:
+```json
+{
+  "recommendations": [
+    {
+      "algorithm": "string",
+      "justification": "string",
+      "confidence_score": integer,
+      "url_slug": "string"
+    }
+  ]
+}
+```

--- a/pipeline/recommender_api.py
+++ b/pipeline/recommender_api.py
@@ -1,0 +1,106 @@
+"""Algorithm Recommender API — lightweight Flask endpoint for LLM-powered recommendations."""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+from pipeline.llm_client import get_provider, generate_with_retry
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+CORS(app)
+
+USE_CASE_MATRIX_PATH = Path("content/use_case_matrix.json")
+RECOMMENDER_PROMPT_PATH = Path(__file__).parent / "prompts" / "recommender_prompt.md"
+
+RECOMMENDATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "recommendations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "algorithm": {"type": "string"},
+                    "justification": {"type": "string"},
+                    "confidence_score": {"type": "integer", "minimum": 1, "maximum": 100},
+                    "url_slug": {"type": "string"},
+                },
+                "required": ["algorithm", "justification", "confidence_score", "url_slug"],
+                "additionalProperties": False,
+            },
+            "minItems": 2,
+            "maxItems": 3,
+        }
+    },
+    "required": ["recommendations"],
+    "additionalProperties": False,
+}
+
+
+def _load_use_case_matrix() -> dict:
+    """Load the use-case matrix JSON, returning empty dict if not found."""
+    if USE_CASE_MATRIX_PATH.exists():
+        return json.loads(USE_CASE_MATRIX_PATH.read_text())
+    logger.warning("use_case_matrix.json not found at %s", USE_CASE_MATRIX_PATH)
+    return {}
+
+
+def _load_prompt_template() -> str:
+    """Load the recommender prompt template."""
+    return RECOMMENDER_PROMPT_PATH.read_text()
+
+
+def get_recommendations(query: str) -> list[dict]:
+    """Send user query + use-case matrix to the LLM and return recommendations."""
+    matrix = _load_use_case_matrix()
+    prompt_template = _load_prompt_template()
+
+    system_prompt = prompt_template.replace("{{use_case_matrix}}", json.dumps(matrix, indent=2))
+    user_prompt = query
+
+    provider = get_provider("recommender")
+    result = generate_with_retry(
+        provider=provider,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        schema=RECOMMENDATION_SCHEMA,
+    )
+    return result["recommendations"]
+
+
+@app.route("/api/recommend", methods=["POST"])
+def recommend():
+    """Handle recommendation requests.
+
+    Expects JSON: {"query": "user's optimization problem description"}
+    Returns JSON: [{"algorithm": ..., "justification": ..., "confidence_score": ..., "url_slug": ...}]
+    """
+    data = request.get_json(silent=True)
+    if not data or not data.get("query", "").strip():
+        return jsonify({"error": "A non-empty 'query' field is required."}), 400
+
+    query = data["query"].strip()
+    if len(query) > 2000:
+        return jsonify({"error": "Query must be 2000 characters or fewer."}), 400
+
+    try:
+        recommendations = get_recommendations(query)
+        return jsonify(recommendations)
+    except Exception as e:
+        logger.exception("Recommendation failed")
+        return jsonify({"error": "Failed to generate recommendations. Please try again."}), 500
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=True)

--- a/pipeline/templates/index.html
+++ b/pipeline/templates/index.html
@@ -27,6 +27,7 @@
         <p>Comprehensive educational content on optimization techniques</p>
     </header>
     <div class="container">
+        {% include "recommender_component.html" %}
         <div class="grid">
             {% for t in techniques %}
             <div class="card">

--- a/pipeline/templates/recommender_component.html
+++ b/pipeline/templates/recommender_component.html
@@ -1,0 +1,296 @@
+<!-- Algorithm Recommender Component -->
+<section id="recommender" class="recommender">
+    <div class="recommender__hero">
+        <h2 class="recommender__title">Algorithm Recommender</h2>
+        <p class="recommender__subtitle">Describe your optimization problem and we'll find the best algorithm for you.</p>
+        <textarea
+            id="recommender-query"
+            class="recommender__textarea"
+            placeholder="Describe your optimization problem (e.g., 'I have a high-dimensional continuous space where evaluations are very expensive...')"
+            rows="4"
+            maxlength="2000"
+        ></textarea>
+        <button id="recommender-btn" class="recommender__btn" onclick="submitRecommendation()">
+            <span id="btn-text">Find Best Algorithm</span>
+            <span id="btn-spinner" class="recommender__spinner" hidden></span>
+        </button>
+        <p id="recommender-error" class="recommender__error" hidden></p>
+    </div>
+
+    <div id="recommender-results" class="recommender__results" hidden>
+        <div id="recommender-cards" class="recommender__cards"></div>
+    </div>
+</section>
+
+<style>
+/* ── Recommender Section ───────────────────────────────────── */
+.recommender {
+    margin: 2.5rem 0;
+}
+
+.recommender__hero {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.recommender__title {
+    font-size: 1.6rem;
+    color: #1a237e;
+    margin-bottom: 0.4rem;
+}
+
+.recommender__subtitle {
+    color: #555;
+    font-size: 0.95rem;
+    margin-bottom: 1.25rem;
+}
+
+.recommender__textarea {
+    width: 100%;
+    padding: 1rem;
+    font-family: inherit;
+    font-size: 1rem;
+    line-height: 1.6;
+    border: 2px solid #d0d5dd;
+    border-radius: 10px;
+    resize: vertical;
+    transition: border-color 0.2s;
+    background: #fff;
+    color: #1a1a2e;
+}
+
+.recommender__textarea:focus {
+    outline: none;
+    border-color: #1a237e;
+    box-shadow: 0 0 0 3px rgba(26, 35, 126, 0.1);
+}
+
+.recommender__textarea::placeholder {
+    color: #98a2b3;
+}
+
+.recommender__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+    padding: 0.85rem 2rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    background: #1a237e;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
+    box-shadow: 0 2px 6px rgba(26, 35, 126, 0.25);
+}
+
+.recommender__btn:hover:not(:disabled) {
+    background: #283593;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(26, 35, 126, 0.35);
+}
+
+.recommender__btn:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+    transform: none;
+}
+
+/* ── Spinner ───────────────────────────────────────────────── */
+.recommender__spinner {
+    width: 18px;
+    height: 18px;
+    border: 2.5px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: rec-spin 0.7s linear infinite;
+}
+
+@keyframes rec-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* ── Error ─────────────────────────────────────────────────── */
+.recommender__error {
+    color: #d32f2f;
+    font-size: 0.9rem;
+    margin-top: 0.75rem;
+}
+
+/* ── Results Cards ─────────────────────────────────────────── */
+.recommender__results {
+    margin-top: 2rem;
+}
+
+.recommender__cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+}
+
+.rec-card {
+    position: relative;
+    background: #fff;
+    border: 1px solid #e4e7ec;
+    border-radius: 10px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    display: flex;
+    flex-direction: column;
+    transition: box-shadow 0.2s, transform 0.2s;
+}
+
+.rec-card:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+}
+
+.rec-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 0.75rem;
+}
+
+.rec-card__name {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #1a237e;
+    margin: 0;
+    padding-right: 0.5rem;
+}
+
+.rec-card__badge {
+    flex-shrink: 0;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.rec-card__badge--green {
+    background: #e8f5e9;
+    color: #2e7d32;
+}
+
+.rec-card__badge--yellow {
+    background: #fff8e1;
+    color: #f57f17;
+}
+
+.rec-card__badge--gray {
+    background: #f5f5f5;
+    color: #616161;
+}
+
+.rec-card__body {
+    flex: 1;
+    font-size: 0.9rem;
+    color: #444;
+    line-height: 1.6;
+    margin-bottom: 1.25rem;
+}
+
+.rec-card__cta {
+    display: block;
+    width: 100%;
+    padding: 0.65rem;
+    text-align: center;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #1a237e;
+    background: #e8eaf6;
+    border: none;
+    border-radius: 6px;
+    text-decoration: none;
+    transition: background 0.2s;
+}
+
+.rec-card__cta:hover {
+    background: #c5cae9;
+}
+</style>
+
+<script>
+const API_URL = "/api/recommend";
+
+async function submitRecommendation() {
+    const textarea = document.getElementById("recommender-query");
+    const btn = document.getElementById("recommender-btn");
+    const btnText = document.getElementById("btn-text");
+    const spinner = document.getElementById("btn-spinner");
+    const errorEl = document.getElementById("recommender-error");
+    const resultsEl = document.getElementById("recommender-results");
+    const cardsEl = document.getElementById("recommender-cards");
+
+    const query = textarea.value.trim();
+    if (!query) {
+        errorEl.textContent = "Please describe your optimization problem.";
+        errorEl.hidden = false;
+        return;
+    }
+
+    /* ── Loading state ──────────────────────────────── */
+    errorEl.hidden = true;
+    resultsEl.hidden = true;
+    btn.disabled = true;
+    btnText.textContent = "Analyzing problem space\u2026";
+    spinner.hidden = false;
+
+    try {
+        const res = await fetch(API_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ query }),
+        });
+
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || "Request failed (" + res.status + ")");
+        }
+
+        const recommendations = await res.json();
+        renderCards(recommendations, cardsEl);
+        resultsEl.hidden = false;
+    } catch (e) {
+        errorEl.textContent = e.message || "Something went wrong. Please try again.";
+        errorEl.hidden = false;
+    } finally {
+        /* ── Reset button ───────────────────────────── */
+        btn.disabled = false;
+        btnText.textContent = "Find Best Algorithm";
+        spinner.hidden = true;
+    }
+}
+
+function renderCards(recommendations, container) {
+    container.innerHTML = "";
+    recommendations.forEach(function (rec) {
+        var badgeClass = "rec-card__badge--gray";
+        if (rec.confidence_score > 80) badgeClass = "rec-card__badge--green";
+        else if (rec.confidence_score > 60) badgeClass = "rec-card__badge--yellow";
+
+        var card = document.createElement("div");
+        card.className = "rec-card";
+        card.innerHTML =
+            '<div class="rec-card__header">' +
+                '<h3 class="rec-card__name">' + escapeHtml(rec.algorithm) + '</h3>' +
+                '<span class="rec-card__badge ' + badgeClass + '">' + rec.confidence_score + '% Match</span>' +
+            '</div>' +
+            '<p class="rec-card__body">' + escapeHtml(rec.justification) + '</p>' +
+            '<a class="rec-card__cta" href="/' + encodeURI(rec.url_slug) + '.html">Read Full Guide</a>';
+        container.appendChild(card);
+    });
+}
+
+function escapeHtml(str) {
+    var div = document.createElement("div");
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+}
+</script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ jsonschema>=4.0.0
 jinja2>=3.0.0
 markdown>=3.0.0
 Pillow>=10.0.0
+flask>=3.0.0
+flask-cors>=4.0.0
 pytest>=7.0.0

--- a/tests/test_recommender_api.py
+++ b/tests/test_recommender_api.py
@@ -1,0 +1,127 @@
+"""Tests for the Algorithm Recommender API endpoint."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from pipeline.recommender_api import app, get_recommendations
+
+
+@pytest.fixture
+def client():
+    """Flask test client."""
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+MOCK_RECOMMENDATIONS = [
+    {
+        "algorithm": "Bayesian Optimization",
+        "justification": "Ideal for expensive black-box evaluations with a small budget.",
+        "confidence_score": 92,
+        "url_slug": "bayesian-optimization",
+    },
+    {
+        "algorithm": "CMA-ES",
+        "justification": "Strong for noisy continuous optimization problems.",
+        "confidence_score": 78,
+        "url_slug": "cma-es",
+    },
+]
+
+
+class TestRecommendEndpoint:
+    def test_missing_query_returns_400(self, client):
+        resp = client.post("/api/recommend", json={})
+        assert resp.status_code == 400
+        assert "query" in resp.get_json()["error"].lower()
+
+    def test_empty_query_returns_400(self, client):
+        resp = client.post("/api/recommend", json={"query": "   "})
+        assert resp.status_code == 400
+
+    def test_no_json_body_returns_400(self, client):
+        resp = client.post("/api/recommend", content_type="application/json", data="")
+        assert resp.status_code == 400
+
+    def test_query_too_long_returns_400(self, client):
+        resp = client.post("/api/recommend", json={"query": "x" * 2001})
+        assert resp.status_code == 400
+        assert "2000" in resp.get_json()["error"]
+
+    @patch("pipeline.recommender_api.get_recommendations")
+    def test_successful_recommendation(self, mock_get, client):
+        mock_get.return_value = MOCK_RECOMMENDATIONS
+        resp = client.post(
+            "/api/recommend",
+            json={"query": "I have a noisy black-box objective with a small budget"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+        assert data[0]["algorithm"] == "Bayesian Optimization"
+        assert data[0]["confidence_score"] == 92
+        assert data[0]["url_slug"] == "bayesian-optimization"
+
+    @patch("pipeline.recommender_api.get_recommendations")
+    def test_llm_failure_returns_500(self, mock_get, client):
+        mock_get.side_effect = RuntimeError("LLM unavailable")
+        resp = client.post(
+            "/api/recommend",
+            json={"query": "some valid query"},
+        )
+        assert resp.status_code == 500
+        assert "error" in resp.get_json()
+
+
+class TestGetRecommendations:
+    @patch("pipeline.recommender_api.generate_with_retry")
+    @patch("pipeline.recommender_api.get_provider")
+    @patch("pipeline.recommender_api._load_prompt_template")
+    @patch("pipeline.recommender_api._load_use_case_matrix")
+    def test_calls_llm_with_query_and_matrix(
+        self, mock_matrix, mock_prompt, mock_provider, mock_generate
+    ):
+        mock_matrix.return_value = {"algorithms": ["Bayesian Optimization"]}
+        mock_prompt.return_value = "System prompt with {{use_case_matrix}}"
+        mock_provider.return_value = MagicMock()
+        mock_generate.return_value = {"recommendations": MOCK_RECOMMENDATIONS}
+
+        result = get_recommendations("noisy black-box")
+
+        mock_matrix.assert_called_once()
+        mock_provider.assert_called_once_with("recommender")
+        assert mock_generate.call_count == 1
+
+        # Verify the matrix was injected into the system prompt
+        call_args = mock_generate.call_args
+        system_prompt = call_args.kwargs.get("system_prompt") or call_args[1].get("system_prompt") or call_args[0][1]
+        assert "Bayesian Optimization" in system_prompt
+
+        assert result == MOCK_RECOMMENDATIONS
+
+    @patch("pipeline.recommender_api.generate_with_retry")
+    @patch("pipeline.recommender_api.get_provider")
+    @patch("pipeline.recommender_api._load_prompt_template")
+    @patch("pipeline.recommender_api._load_use_case_matrix")
+    def test_empty_matrix_still_works(
+        self, mock_matrix, mock_prompt, mock_provider, mock_generate
+    ):
+        mock_matrix.return_value = {}
+        mock_prompt.return_value = "Prompt {{use_case_matrix}}"
+        mock_provider.return_value = MagicMock()
+        mock_generate.return_value = {"recommendations": MOCK_RECOMMENDATIONS}
+
+        result = get_recommendations("some query")
+        assert len(result) == 2
+
+
+class TestProviderMapping:
+    def test_recommender_mapped_in_config(self):
+        from pipeline.llm_client import load_config
+
+        config = load_config()
+        assert "recommender" in config["artifact_provider_map"]


### PR DESCRIPTION
- Create Flask API endpoint (POST /api/recommend) that accepts a natural
  language query, sends it with the use-case matrix to the LLM via the
  existing llm_client, and returns 2-3 algorithm recommendations with
  confidence scores, justifications, and URL slugs.
- Add recommender Jinja component with three UI states (input, loading,
  results) featuring a hero textarea, animated loading spinner, and
  responsive recommendation cards with color-coded confidence badges.
- Integrate component into the index.html homepage template.
- Add recommender prompt template and provider mapping in config.json.
- Add flask/flask-cors to requirements.txt.
- Add comprehensive test suite (9 tests) covering endpoint validation,
  LLM integration, and error handling.

https://claude.ai/code/session_01WDDsYNDGZJ6axTErwpRxNP