### PR TITLE
Fix formatting bleed from unbalanced markdown and improve infographic quality

### DIFF
--- a/pipeline/prompts/infographic_image_prompt.md
+++ b/pipeline/prompts/infographic_image_prompt.md
@@ -1,27 +1,30 @@
-Create a professional educational infographic about {{technique_name}}.
+Create a professional educational infographic image about {{technique_name}}.
 
 Title: {{title}}
 
 Layout: {{layout}}
 
-**Content to include (render these):**
+**Content to include (render visually — use diagrams, charts, and illustrations, NOT walls of text):**
 Panels:
 {{formatted_panels}}
 
 Key Equations (render as LaTeX in the image):
 {{formatted_equations}}
 
-Visual Metaphors:
+Visual Metaphors (illustrate these as diagrams or icons, do not just write them as text):
 {{formatted_metaphors}}
 
 **Design guidance (apply invisibly — do NOT display as text):**
 - Color palette: {{color_palette}} — Use these colors throughout the design. Never show color swatches, hex codes, or a "color palette" section in the image.
 - Typography: {{typography}} — Use these font styles and sizes. Never display font names, point sizes, or typography specifications as visible text.
 
-**Style requirements:**
+**Critical style requirements:**
+- VISUAL-FIRST: Use diagrams, flowcharts, illustrated processes, icons, and charts as the primary content. Text should be limited to short labels, captions, and the title. Do NOT render long sentences or paragraphs as text in the image — represent ideas visually instead.
+- Every panel must contain a dominant visual element (diagram, chart, illustration, or icon). Text captions should be 10 words or fewer per label.
+- For equations: render only the 2-3 most important equations. Keep them large, clear, and visually prominent with proper mathematical notation. Do not include derivation steps — just the key results.
+- The infographic must be clearly and specifically about {{technique_name}} — include algorithm-specific visual elements (e.g., tree structures for tree search, particle diagrams for swarm methods, fitness landscapes for evolutionary algorithms).
 - Clean, modern design suitable for technical education
-- All text must be legible and correctly rendered
-- Equations should be rendered clearly with proper mathematical notation
-- Each panel should be visually distinct but cohesive
+- All text that does appear must be legible, correctly spelled, and correctly rendered
+- Each panel should be visually distinct but cohesive with a unified color scheme
 - Resolution: high quality, suitable for web and print
 - No metadata, design specs, or behind-the-scenes information should appear in the final image

--- a/pipeline/prompts/infographic_prompt.md
+++ b/pipeline/prompts/infographic_prompt.md
@@ -13,13 +13,15 @@ Return a JSON object with these fields:
 - **artifact_type** (string): "infographic_spec"
 - **title** (string): A compelling title for the infographic.
 - **panels** (array of objects): At least 4 panels, each with:
-  - "title" (string): Panel heading
-  - "content" (string): Text content for this panel
-  - "visual_type" (string): Type of visual (e.g., "flowchart", "graph", "diagram", "comparison_table")
-- **visual_metaphors** (array of strings): At least 2 visual metaphors or analogies to make the technique intuitive.
+  - "title" (string): Panel heading (short — 5 words or fewer)
+  - "content" (string): A brief description of what this panel shows visually. Focus on what diagram, chart, or illustration to draw — NOT paragraphs of explanatory text. Keep to 1-2 short sentences.
+  - "visual_type" (string): Type of visual (e.g., "flowchart", "graph", "diagram", "comparison_table", "icon_grid", "process_illustration", "annotated_figure")
+- **visual_metaphors** (array of strings): At least 2 visual metaphors or analogies to make the technique intuitive. Each should be something that can be drawn as an illustration, not just described in words.
 - **color_palette** (string): A description of the color scheme (e.g., "Deep blue (#1a237e) primary, teal (#00897b) accent, light gray (#f5f5f5) background").
 - **layout** (string): Description of the overall layout (e.g., "Vertical scroll, 2-column grid for panels, full-width header and footer").
 - **typography** (string): Font and sizing guidance (e.g., "Title: 32pt bold sans-serif, Body: 14pt regular, Equations: 16pt serif italic").
-- **key_equations** (array of strings): The 2-4 most visually important equations in LaTeX, to be rendered prominently in the infographic.
+- **key_equations** (array of strings): The 2-3 most visually important equations in LaTeX, to be rendered prominently in the infographic. Only include the final result forms — no derivation steps.
+
+**Important**: Design for visual impact. Each panel should be dominated by a diagram, chart, or illustration — not by text. The infographic will be generated as an image, so text-heavy panels will be unreadable. Prefer flowcharts, annotated diagrams, process illustrations, and comparison charts over textual explanations.
 
 Respond with ONLY the JSON object, no additional text.

--- a/pipeline/publish.py
+++ b/pipeline/publish.py
@@ -97,6 +97,58 @@ def _ensure_bullet_lists(text: str) -> str:
     return re.sub(r":\s*\n(\s*-\s)", r":\n\n\1", text)
 
 
+def _balance_bold_italic(text: str) -> str:
+    """Fix unbalanced ``**`` and ``*`` markers that cause paragraphs to be entirely bold/italic.
+
+    Operates per-paragraph so an unclosed marker in one block cannot bleed into the next.
+    """
+
+    def _fix_paragraph(para: str) -> str:
+        # Fix unbalanced ** (bold)
+        bold_count = len(re.findall(r"(?<!\*)\*\*(?!\*)", para))
+        if bold_count % 2 != 0:
+            # Remove the last unmatched ** rather than leaving it open
+            # Find the last ** and remove it
+            para = _remove_last_occurrence(para, "**")
+
+        # Fix unbalanced * (italic) — but skip * inside ** pairs
+        # First mask out ** pairs, then count remaining *
+        masked = re.sub(r"\*\*", "@@DBL@@", para)
+        star_count = masked.count("*")
+        if star_count % 2 != 0:
+            # Remove the last unmatched *
+            para = _remove_last_occurrence(para, "*")
+
+        return para
+
+    paragraphs = text.split("\n\n")
+    return "\n\n".join(_fix_paragraph(p) for p in paragraphs)
+
+
+def _remove_last_occurrence(text: str, marker: str) -> str:
+    """Remove the last occurrence of *marker* in *text*."""
+    idx = text.rfind(marker)
+    if idx == -1:
+        return text
+    return text[:idx] + text[idx + len(marker):]
+
+
+def _close_unclosed_tags(html: str) -> str:
+    """Close ``<strong>`` and ``<em>`` tags left open by the markdown parser.
+
+    Uses a lightweight approach: count opens vs closes and append closing tags
+    at the end of each ``<p>`` / ``<li>`` block so formatting cannot bleed.
+    """
+    for tag in ("strong", "em"):
+        open_tag = f"<{tag}>"
+        close_tag = f"</{tag}>"
+        opens = html.count(open_tag)
+        closes = html.count(close_tag)
+        if opens > closes:
+            html += close_tag * (opens - closes)
+    return html
+
+
 def _strip_redundant_leading_heading(text: str, _section_title: str = "") -> str:
     """Remove a leading # or ## line that duplicates the section context."""
     text = text.strip()
@@ -139,7 +191,9 @@ def _render_markdown(
         text = _downgrade_headers(text)
 
     text, math_placeholders = _extract_math_segments(text)
+    text = _balance_bold_italic(text)
     html = markdown.markdown(text, extensions=["fenced_code", "tables", "sane_lists"])
+    html = _close_unclosed_tags(html)
     return _restore_placeholders(html, math_placeholders)
 
 

--- a/tests/test_publish_rendering.py
+++ b/tests/test_publish_rendering.py
@@ -2,7 +2,11 @@
 
 import json
 
-from pipeline.publish import md_to_html
+from pipeline.publish import (
+    _balance_bold_italic,
+    _close_unclosed_tags,
+    md_to_html,
+)
 
 
 class TestMarkdownRendering:
@@ -17,6 +21,34 @@ class TestMarkdownRendering:
 
         assert "<li>First item</li>" in html
         assert "<li>Second item</li>" in html
+
+    def test_unbalanced_bold_does_not_bleed(self):
+        """An unclosed ** must not make the next paragraph bold."""
+        text = "This is **broken bold\n\nThis paragraph should be normal."
+        html = md_to_html(text)
+        # The second paragraph should NOT be wrapped in <strong>
+        assert "<strong>This paragraph" not in html
+
+    def test_unbalanced_italic_does_not_bleed(self):
+        text = "Here is *broken italic\n\nNormal text follows."
+        html = md_to_html(text)
+        assert "<em>Normal text" not in html
+
+    def test_balanced_bold_preserved(self):
+        text = "This is **properly bold** text."
+        html = md_to_html(text)
+        assert "<strong>properly bold</strong>" in html
+
+    def test_close_unclosed_strong_tags(self):
+        html = "<p><strong>open bold</p><p>next paragraph</p>"
+        fixed = _close_unclosed_tags(html)
+        assert fixed.count("</strong>") == 1
+
+    def test_balance_bold_italic_removes_trailing_stars(self):
+        text = "Some **unmatched bold text"
+        result = _balance_bold_italic(text)
+        # The unmatched ** should be removed
+        assert result.count("**") == 0
 
 
 class TestPublishLifecycle:


### PR DESCRIPTION
1. Formatting: Add _balance_bold_italic() pre-processor to fix unmatched ** and *
   markers per paragraph, and _close_unclosed_tags() post-processor to catch any
   remaining unclosed <strong>/<em> tags. This prevents whole paragraphs from
   rendering as bold/italic when the LLM produces unbalanced markers.

2. Infographics: Rewrite both prompt templates to emphasize visual-first design.
   Panels now require dominant visual elements (diagrams, charts, illustrations)
   with text limited to short labels. Equations reduced to 2-3 key results only.
   Added explicit technique-specific visual element guidance.

https://claude.ai/code/session_015xbySAaxN7yjUDWHWamvmT