### PR TITLE
Fix Read Full Guide link in recommender

### DIFF
--- a/pipeline/prompts/recommender_prompt.md
+++ b/pipeline/prompts/recommender_prompt.md
@@ -11,7 +11,7 @@ Based on the user's problem description, recommend exactly 2-3 algorithms that b
 1. **algorithm**: The exact name of the algorithm (must match one from the matrix).
 2. **justification**: A clear 2-3 sentence explanation of why this algorithm is a good fit for their specific problem. Reference specific aspects of their problem description.
 3. **confidence_score**: An integer from 1-100 indicating how confident you are that this algorithm is appropriate. Be calibrated — use 90+ only for near-perfect matches.
-4. **url_slug**: The URL-friendly slug for the algorithm (lowercase, hyphens instead of spaces). For example, "Bayesian Optimization" becomes "bayesian-optimization".
+4. **url_slug**: The URL-friendly slug for the algorithm (lowercase, hyphens instead of spaces). For example, "UCT Upper Confidence Bounds for Trees" becomes "uct-upper-confidence-bounds-for-trees".
 
 Order recommendations from highest to lowest confidence score.
 

--- a/pipeline/templates/recommender_component.html
+++ b/pipeline/templates/recommender_component.html
@@ -283,7 +283,7 @@ function renderCards(recommendations, container) {
                 '<span class="rec-card__badge ' + badgeClass + '">' + rec.confidence_score + '% Match</span>' +
             '</div>' +
             '<p class="rec-card__body">' + escapeHtml(rec.justification) + '</p>' +
-            '<a class="rec-card__cta" href="/' + encodeURI(rec.url_slug) + '.html">Read Full Guide</a>';
+            '<a class="rec-card__cta" href="' + encodeURI(rec.url_slug) + '.html">Read Full Guide</a>';
         container.appendChild(card);
     });
 }


### PR DESCRIPTION
## Summary
- Remove leading slash from the Read Full Guide href so links resolve as relative paths instead of absolute — fixes 404s when the site is served from a subdirectory or opened as local files
- Update stale url_slug example in the recommender prompt from `bayesian-optimization` to an actual MCTS technique name

## Test plan
- [ ] Run `python -m pipeline.publish` and open `site/index.html` locally
- [ ] Use the Algorithm Recommender and click Read Full Guide on a result card
- [ ] Verify the link navigates to the correct technique page

Generated with [Claude Code](https://claude.com/claude-code)