### PR TITLE
Add tool-calling judge and asymmetric model routing

### DIFF
--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -26,6 +26,10 @@
       "model": "gemini-3.1-pro-preview",
       "api_key_env": "GEMINI_API_KEY"
     },
+    "gemini_flash": {
+      "model": "gemini-3.1-flash-preview",
+      "api_key_env": "GEMINI_API_KEY"
+    },
     "nano_banana": {
       "model": "gemini-3.1-flash-image-preview",
       "api_key_env": "GEMINI_API_KEY"
@@ -43,12 +47,12 @@
   },
   "implementation_disallowed_terms": {},
   "artifact_provider_map": {
-    "plan": "gemini",
-    "overview": "gemini",
-    "math_deep_dive": "gemini",
-    "implementation": "gemini",
-    "infographic_spec": "gemini",
-    "homepage_summary": "gemini",
+    "plan": "gemini_flash",
+    "overview": "gemini_flash",
+    "math_deep_dive": "gemini_flash",
+    "implementation": "gemini_flash",
+    "infographic_spec": "gemini_flash",
+    "homepage_summary": "gemini_flash",
     "infographic_image": "nano_banana",
     "recommender": "gemini",
     "math_tutor": "gemini",
@@ -56,7 +60,7 @@
     "study_plan": "gemini",
     "adapt_code": "gemini",
     "judge": "gemini",
-    "knowledge_graph": "gemini",
-    "playground_config": "gemini"
+    "knowledge_graph": "gemini_flash",
+    "playground_config": "gemini_flash"
   }
 }

--- a/pipeline/judge.py
+++ b/pipeline/judge.py
@@ -2,8 +2,12 @@
 
 import json
 import logging
+import re
 from typing import Any
 
+import jsonschema
+
+from pipeline.judge_tools import dispatch_tool, tool_declarations
 from pipeline.llm_client import generate_with_retry, get_provider
 from pipeline.paths import REFERENCE_DIR, RUBRICS_PATH
 
@@ -134,11 +138,103 @@ def _build_judge_prompt(
     return system_prompt, user_prompt
 
 
+def _build_tool_using_judge_prompt(
+    technique_slug: str,
+    artifact_type: str,
+    artifact_data: dict[str, Any],
+    rubrics: dict[str, Any],
+) -> tuple[str, str]:
+    """Build prompts for the tool-using judge.
+
+    The reference data is fetched on demand via the ``lookup_reference`` tool
+    rather than embedded inline, which saves tokens and forces the judge to
+    actively ground its claims.
+    """
+    threshold = rubrics.get("pass_threshold", DEFAULT_PASS_THRESHOLD)
+    criteria_desc = "\n".join(
+        f"- {name}: {info['description']}"
+        for name, info in rubrics.get("criteria", {}).items()
+    )
+    schema_hint = json.dumps(JUDGE_OUTPUT_SCHEMA, indent=2)
+
+    system_prompt = (
+        "You are a strict educational content evaluator with access to "
+        "verification tools. Before scoring, use the tools to:\n"
+        f"  1. Call lookup_reference('{technique_slug}') to fetch canonical "
+        "facts and forbidden claims for this technique.\n"
+        "  2. For implementation artifacts, call run_python_code on the "
+        "python_examples to confirm they execute without errors.\n"
+        "  3. For implementation artifacts, call verify_imports on the "
+        "runtime_dependencies to detect hallucinated imports.\n"
+        "  4. For math-heavy artifacts, call check_equation on questionable "
+        "LaTeX expressions to catch malformed equations.\n\n"
+        "Once you have enough evidence, score each rubric criterion from "
+        f"1-10. Set passed=true only if overall_score >= {threshold}. "
+        "Provide specific critiques and actionable revision instructions.\n\n"
+        "Final answer MUST be a single JSON object matching this schema "
+        "(no markdown fences, no commentary):\n"
+        f"{schema_hint}"
+    )
+
+    user_prompt = (
+        f"## Technique: {technique_slug}\n"
+        f"## Artifact Type: {artifact_type}\n\n"
+        f"## Evaluation Criteria\n{criteria_desc}\n"
+        f"## Pass Threshold: {threshold}/10\n\n"
+        f"## Artifact Content\n```json\n{json.dumps(artifact_data, indent=2)[:8000]}\n```\n\n"
+        "Use the available tools to verify the artifact, then return your "
+        "final evaluation as JSON."
+    )
+
+    return system_prompt, user_prompt
+
+
+def _parse_judge_json(text: str) -> dict[str, Any] | None:
+    """Best-effort extraction of the judge's final JSON object from raw text."""
+    if not text:
+        return None
+    candidates: list[str] = [text.strip()]
+
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
+    if fenced:
+        candidates.append(fenced.group(1))
+
+    first_brace = text.find("{")
+    last_brace = text.rfind("}")
+    if first_brace != -1 and last_brace > first_brace:
+        candidates.append(text[first_brace : last_brace + 1])
+
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _judge_failure_payload(
+    reason: str, tool_calls: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """Standard shape for a failed judge run so callers can rely on it."""
+    return {
+        "passed": False,
+        "overall_score": 0,
+        "criteria_scores": {},
+        "critiques": [reason],
+        "revision_instructions": [],
+        "tool_calls": tool_calls or [],
+    }
+
+
 def evaluate_artifact(
     technique_slug: str,
     artifact_type: str,
     artifact_data: dict[str, Any],
     provider_override=None,
+    use_tools: bool = True,
+    max_tool_iterations: int = 5,
 ) -> dict[str, Any]:
     """Evaluate an artifact using the LLM judge.
 
@@ -147,33 +243,79 @@ def evaluate_artifact(
         artifact_type: The artifact type being evaluated.
         artifact_data: The artifact content to evaluate.
         provider_override: Optional provider name override.
+        use_tools: When True, run the judge as a tool-using agent that can
+            execute code, verify imports, check LaTeX, and look up canonical
+            references before scoring. When False, fall back to the legacy
+            one-shot path that embeds the reference inline.
+        max_tool_iterations: Maximum tool-use turns before the judge must
+            commit to a final score.
 
     Returns:
         Judge output dict with passed, overall_score, criteria_scores,
-        critiques, and revision_instructions.
+        critiques, revision_instructions, and (when ``use_tools`` is True)
+        ``tool_calls`` documenting each tool invocation.
     """
     rubrics = load_rubrics()
-    reference = load_reference(technique_slug)
+    provider = get_provider("judge", override=provider_override)
 
+    if use_tools and hasattr(provider, "generate_with_tools"):
+        system_prompt, user_prompt = _build_tool_using_judge_prompt(
+            technique_slug, artifact_type, artifact_data, rubrics
+        )
+        try:
+            loop_result = provider.generate_with_tools(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                tools=tool_declarations(),
+                dispatch=dispatch_tool,
+                max_iterations=max_tool_iterations,
+            )
+        except Exception as e:
+            logger.error(
+                "Tool-using judge failed for %s/%s: %s",
+                technique_slug,
+                artifact_type,
+                e,
+            )
+            return _judge_failure_payload(f"Tool-using judge raised: {e}")
+
+        parsed = _parse_judge_json(loop_result.get("text", ""))
+        tool_calls = loop_result.get("tool_calls", [])
+        if parsed is None:
+            return _judge_failure_payload(
+                "Judge did not return valid JSON after tool use",
+                tool_calls=tool_calls,
+            )
+        try:
+            jsonschema.validate(instance=parsed, schema=JUDGE_OUTPUT_SCHEMA)
+        except jsonschema.ValidationError as e:
+            return _judge_failure_payload(
+                f"Judge JSON failed schema validation: {e.message}",
+                tool_calls=tool_calls,
+            )
+        parsed["tool_calls"] = tool_calls
+        parsed["iterations"] = loop_result.get("iterations", 1)
+        return parsed
+
+    # Legacy one-shot path (no tools)
+    reference = load_reference(technique_slug)
     system_prompt, user_prompt = _build_judge_prompt(
         artifact_type, artifact_data, rubrics, reference
     )
-
-    provider = get_provider("judge", override=provider_override)
     try:
         result = generate_with_retry(
             provider, system_prompt, user_prompt, JUDGE_OUTPUT_SCHEMA
         )
+        result.setdefault("tool_calls", [])
         return result
     except Exception as e:
-        logger.error("Judge evaluation failed for %s/%s: %s", technique_slug, artifact_type, e)
-        return {
-            "passed": False,
-            "overall_score": 0,
-            "criteria_scores": {},
-            "critiques": [f"Judge evaluation failed: {e}"],
-            "revision_instructions": [],
-        }
+        logger.error(
+            "Judge evaluation failed for %s/%s: %s",
+            technique_slug,
+            artifact_type,
+            e,
+        )
+        return _judge_failure_payload(f"Judge evaluation failed: {e}")
 
 
 def build_revision_prompt(

--- a/pipeline/judge_tools.py
+++ b/pipeline/judge_tools.py
@@ -1,0 +1,245 @@
+"""Tool registry for the tool-calling judge.
+
+Each tool exposes a Python callable plus a JSON-Schema declaration. The
+GeminiProvider tool-use loop dispatches by name into TOOL_REGISTRY, executes
+the callable with the LLM-supplied arguments, and feeds the result back to
+the model.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+from pipeline.code_runner import check_dependencies, run_code
+from pipeline.paths import REFERENCE_DIR
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+def run_python_code(code: str, timeout_s: int = 15) -> dict[str, Any]:
+    """Execute a Python snippet in the existing subprocess sandbox."""
+    if not isinstance(code, str) or not code.strip():
+        return {"error": "code must be a non-empty string"}
+    if timeout_s <= 0 or timeout_s > 30:
+        timeout_s = 15
+    result = run_code(code, timeout=timeout_s)
+    return {
+        "passed": result["passed"],
+        "exit_code": result["exit_code"],
+        "stdout": result["stdout"][:2000],
+        "stderr": result["stderr"][:2000],
+        "timeout_s": timeout_s,
+    }
+
+
+_LATEX_DELIM_RE = re.compile(r"^\s*(\$\$|\$|\\\(|\\\[)|(\$\$|\$|\\\)|\\\])\s*$")
+_KNOWN_COMMANDS = {
+    "frac", "sqrt", "sum", "prod", "int", "lim", "log", "ln", "exp", "sin", "cos",
+    "tan", "cot", "sec", "csc", "arcsin", "arccos", "arctan", "sinh", "cosh", "tanh",
+    "alpha", "beta", "gamma", "delta", "epsilon", "varepsilon", "zeta", "eta", "theta",
+    "vartheta", "iota", "kappa", "lambda", "mu", "nu", "xi", "pi", "rho", "sigma",
+    "tau", "upsilon", "phi", "varphi", "chi", "psi", "omega", "Gamma", "Delta",
+    "Theta", "Lambda", "Xi", "Pi", "Sigma", "Upsilon", "Phi", "Psi", "Omega",
+    "infty", "partial", "nabla", "cdot", "times", "div", "pm", "mp", "leq", "geq",
+    "neq", "approx", "sim", "equiv", "in", "notin", "subset", "subseteq", "supset",
+    "supseteq", "cup", "cap", "emptyset", "forall", "exists", "rightarrow", "leftarrow",
+    "Rightarrow", "Leftarrow", "leftrightarrow", "Leftrightarrow", "mapsto", "to",
+    "left", "right", "big", "Big", "bigg", "Bigg", "mathbb", "mathbf", "mathcal",
+    "mathrm", "text", "textbf", "textit", "boldsymbol", "hat", "tilde", "bar", "vec",
+    "dot", "ddot", "underline", "overline", "begin", "end", "argmax", "argmin", "max",
+    "min", "sup", "inf", "det", "dim", "ker", "Pr", "mathbb",
+}
+
+
+def check_equation(latex: str) -> dict[str, Any]:
+    """Run syntactic validity checks on a LaTeX equation string.
+
+    Returns ``parsable`` False when delimiters are unbalanced or unknown
+    commands appear; the model can then revise the artifact accordingly.
+    """
+    if not isinstance(latex, str) or not latex.strip():
+        return {"error": "latex must be a non-empty string"}
+
+    errors: list[str] = []
+    body = _LATEX_DELIM_RE.sub("", latex.strip()).strip()
+
+    pairs = [("{", "}"), ("[", "]"), ("(", ")")]
+    for opener, closer in pairs:
+        opens = body.count(opener)
+        closes = body.count(closer)
+        if opens != closes:
+            errors.append(
+                f"Unbalanced '{opener}{closer}': {opens} opens vs {closes} closes"
+            )
+
+    unknown: set[str] = set()
+    for match in re.finditer(r"\\([A-Za-z]+)", body):
+        cmd = match.group(1)
+        if cmd not in _KNOWN_COMMANDS:
+            unknown.add(cmd)
+    if unknown:
+        errors.append(f"Unknown LaTeX commands: {sorted(unknown)}")
+
+    if re.search(r"\\([A-Za-z]+)\1\b", body):
+        errors.append("Possible duplicated command name (e.g. \\fracfrac)")
+
+    return {
+        "parsable": len(errors) == 0,
+        "errors": errors,
+        "body_length": len(body),
+    }
+
+
+def lookup_reference(technique_slug: str) -> dict[str, Any]:
+    """Return canonical reference facts for a technique, if available."""
+    if not isinstance(technique_slug, str) or not technique_slug.strip():
+        return {"error": "technique_slug must be a non-empty string"}
+
+    ref_path = REFERENCE_DIR / f"{technique_slug}.json"
+    if not ref_path.exists():
+        return {
+            "found": False,
+            "technique_slug": technique_slug,
+            "message": f"No reference file at {ref_path}",
+        }
+
+    import json
+
+    try:
+        data = json.loads(ref_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        return {"error": f"Failed to load reference: {e}"}
+
+    return {
+        "found": True,
+        "technique_slug": technique_slug,
+        "key_facts": data.get("key_facts", []),
+        "forbidden_claims": data.get("forbidden_claims", []),
+    }
+
+
+def verify_imports(deps: list[str]) -> dict[str, Any]:
+    """Check whether a list of declared dependencies is allowlisted and importable."""
+    if not isinstance(deps, list):
+        return {"error": "deps must be a list of strings"}
+    deps_clean = [d for d in deps if isinstance(d, str) and d.strip()]
+    return check_dependencies(deps_clean)
+
+
+# ---------------------------------------------------------------------------
+# Tool registry — schemas in JSON Schema form
+# ---------------------------------------------------------------------------
+
+TOOL_REGISTRY: dict[str, dict[str, Any]] = {
+    "run_python_code": {
+        "function": run_python_code,
+        "description": (
+            "Execute a Python snippet in a sandboxed subprocess and return "
+            "stdout, stderr, and exit_code. Use this to verify that "
+            "implementation code in an artifact actually runs."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "Python source code to execute.",
+                },
+                "timeout_s": {
+                    "type": "integer",
+                    "description": "Timeout in seconds (1-30, default 15).",
+                },
+            },
+            "required": ["code"],
+        },
+    },
+    "check_equation": {
+        "function": check_equation,
+        "description": (
+            "Validate a LaTeX equation for balanced delimiters and known "
+            "commands. Returns parsable=false with a list of errors if "
+            "the equation is malformed."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "latex": {
+                    "type": "string",
+                    "description": "The LaTeX equation, with or without delimiters.",
+                },
+            },
+            "required": ["latex"],
+        },
+    },
+    "lookup_reference": {
+        "function": lookup_reference,
+        "description": (
+            "Fetch canonical key_facts and forbidden_claims for a technique. "
+            "Use this to ground factual claims in the artifact against "
+            "trusted reference material."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "technique_slug": {
+                    "type": "string",
+                    "description": "Slug like 'uct-upper-confidence-bounds-for-trees'.",
+                },
+            },
+            "required": ["technique_slug"],
+        },
+    },
+    "verify_imports": {
+        "function": verify_imports,
+        "description": (
+            "Check whether declared Python dependencies are allowlisted and "
+            "importable. Use this to detect hallucinated imports in "
+            "implementation artifacts."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "deps": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of module names declared by the artifact.",
+                },
+            },
+            "required": ["deps"],
+        },
+    },
+}
+
+
+def dispatch_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch a tool call by name. Tool errors are returned as data, not raised."""
+    entry = TOOL_REGISTRY.get(name)
+    if entry is None:
+        return {"error": f"Unknown tool: {name}"}
+    fn: Callable[..., dict[str, Any]] = entry["function"]
+    try:
+        return fn(**arguments)
+    except TypeError as e:
+        return {"error": f"Bad arguments for {name}: {e}"}
+    except Exception as e:  # noqa: BLE001 — surface to model rather than crash loop
+        logger.exception("Tool %s raised", name)
+        return {"error": f"{type(e).__name__}: {e}"}
+
+
+def tool_declarations() -> list[dict[str, Any]]:
+    """Return the tool schemas in the shape Gemini's function calling expects."""
+    return [
+        {
+            "name": name,
+            "description": entry["description"],
+            "parameters": entry["parameters"],
+        }
+        for name, entry in TOOL_REGISTRY.items()
+    ]

--- a/pipeline/llm_client.py
+++ b/pipeline/llm_client.py
@@ -7,8 +7,9 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
+from typing import Any
 
 from dotenv import load_dotenv
 
@@ -110,6 +111,102 @@ class GeminiProvider(LLMProvider):
             if chunk.text:
                 yield chunk.text
 
+    def generate_with_tools(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        tools: list[dict],
+        dispatch: Callable[[str, dict], dict],
+        max_iterations: int = 5,
+    ) -> dict:
+        """Run a tool-use loop and return the final text plus the tool-call history.
+
+        The loop sends the system+user prompts to Gemini with the supplied tool
+        declarations. On each turn the model can either return text (the final
+        answer) or one or more ``function_call`` parts. Function calls are
+        dispatched via ``dispatch(name, args)``; the return value is sent back
+        to the model as a ``function_response`` and the loop continues.
+
+        Returns a dict with ``text`` (final model output as a string),
+        ``tool_calls`` (list of {name, args, result}), and ``iterations``.
+        """
+        function_decls = [
+            genai_types.FunctionDeclaration(
+                name=tool["name"],
+                description=tool["description"],
+                parameters=tool["parameters"],
+            )
+            for tool in tools
+        ]
+        gemini_tool = genai_types.Tool(function_declarations=function_decls)
+        config = genai_types.GenerateContentConfig(
+            system_instruction=system_prompt,
+            tools=[gemini_tool],
+        )
+
+        contents: list[Any] = [
+            genai_types.Content(
+                role="user",
+                parts=[genai_types.Part.from_text(text=user_prompt)],
+            )
+        ]
+        tool_calls: list[dict] = []
+        final_text = ""
+
+        for iteration in range(1, max_iterations + 1):
+            response = self.client.models.generate_content(
+                model=self.model,
+                contents=contents,
+                config=config,
+            )
+            candidate = response.candidates[0]
+            parts = list(candidate.content.parts or [])
+
+            fn_calls = [p for p in parts if getattr(p, "function_call", None)]
+            text_parts = [p.text for p in parts if getattr(p, "text", None)]
+
+            if not fn_calls:
+                final_text = "".join(text_parts).strip()
+                return {
+                    "text": final_text,
+                    "tool_calls": tool_calls,
+                    "iterations": iteration,
+                }
+
+            contents.append(candidate.content)
+
+            response_parts = []
+            for part in fn_calls:
+                fn_call = part.function_call
+                args = dict(fn_call.args) if fn_call.args else {}
+                result = dispatch(fn_call.name, args)
+                tool_calls.append({
+                    "name": fn_call.name,
+                    "args": args,
+                    "result": result,
+                    "iteration": iteration,
+                })
+                response_parts.append(
+                    genai_types.Part.from_function_response(
+                        name=fn_call.name,
+                        response=result,
+                    )
+                )
+            contents.append(
+                genai_types.Content(role="user", parts=response_parts)
+            )
+
+        logger.warning(
+            "Tool-use loop hit max_iterations=%d without a final answer",
+            max_iterations,
+        )
+        return {
+            "text": final_text,
+            "tool_calls": tool_calls,
+            "iterations": max_iterations,
+            "max_iterations_reached": True,
+        }
+
 
 class NanoBananaProvider:
     """Generates infographic images via Nano Banana Pro (Gemini 3 Image)."""
@@ -177,7 +274,7 @@ def get_provider(
             model=provider_config["model"],
             api_key_env=provider_config["api_key_env"],
         )
-    elif provider_name == "gemini":
+    elif provider_name.startswith("gemini"):
         provider = GeminiProvider(
             model=provider_config["model"],
             api_key_env=provider_config["api_key_env"],

--- a/pipeline/retry_loop.py
+++ b/pipeline/retry_loop.py
@@ -120,6 +120,7 @@ def retry_loop(
             "attempt": attempt,
             "stage": "judge",
             "result": judge_result,
+            "tool_calls": judge_result.get("tool_calls", []),
         })
 
         if judge_result.get("passed", False):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -95,7 +95,9 @@ class TestEvaluateArtifact:
             "revision_instructions": [],
         }
 
-        result = evaluate_artifact("cma-es", "overview", {"markdown": "content"})
+        result = evaluate_artifact(
+            "cma-es", "overview", {"markdown": "content"}, use_tools=False
+        )
         assert result["passed"] is True
         assert result["overall_score"] == 8
 
@@ -111,7 +113,9 @@ class TestEvaluateArtifact:
         mock_provider.return_value = MagicMock()
         mock_generate.side_effect = RuntimeError("API error")
 
-        result = evaluate_artifact("cma-es", "overview", {"markdown": "content"})
+        result = evaluate_artifact(
+            "cma-es", "overview", {"markdown": "content"}, use_tools=False
+        )
         assert result["passed"] is False
         assert result["overall_score"] == 0
 

--- a/tests/test_judge_tools.py
+++ b/tests/test_judge_tools.py
@@ -1,0 +1,364 @@
+"""Tests for the tool-calling judge: tool functions, dispatch, and the loop."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipeline.judge import evaluate_artifact
+from pipeline.judge_tools import (
+    TOOL_REGISTRY,
+    check_equation,
+    dispatch_tool,
+    lookup_reference,
+    run_python_code,
+    tool_declarations,
+    verify_imports,
+)
+
+
+class TestRunPythonCode:
+    def test_happy_path(self):
+        result = run_python_code("print('hello')")
+        assert result["passed"] is True
+        assert "hello" in result["stdout"]
+        assert result["exit_code"] == 0
+
+    def test_runtime_error_captured(self):
+        result = run_python_code("raise ValueError('boom')")
+        assert result["passed"] is False
+        assert "ValueError" in result["stderr"]
+
+    def test_rejects_empty(self):
+        assert run_python_code("")["error"]
+        assert run_python_code("   ")["error"]
+
+    def test_rejects_non_string(self):
+        # type: ignore[arg-type] — exercising the type guard
+        assert run_python_code(123)["error"]  # type: ignore[arg-type]
+
+    def test_clamps_timeout(self):
+        result = run_python_code("print(1)", timeout_s=999)
+        assert result["timeout_s"] == 15  # clamped to default
+        assert result["passed"] is True
+
+
+class TestCheckEquation:
+    def test_well_formed(self):
+        result = check_equation(r"$\sum_{i=1}^n x_i = \frac{a}{b}$")
+        assert result["parsable"] is True
+        assert result["errors"] == []
+
+    def test_unbalanced_braces(self):
+        result = check_equation(r"\frac{a}{b")
+        assert result["parsable"] is False
+        assert any("Unbalanced '{}'" in e for e in result["errors"])
+
+    def test_unknown_command(self):
+        result = check_equation(r"$\fract{a}{b}$")
+        assert result["parsable"] is False
+        assert any("Unknown LaTeX commands" in e for e in result["errors"])
+
+    def test_rejects_empty(self):
+        assert "error" in check_equation("")
+        assert "error" in check_equation("   ")
+
+
+class TestLookupReference:
+    def test_missing_file(self):
+        result = lookup_reference("nonexistent-technique-xyz")
+        assert result["found"] is False
+
+    def test_existing_file(self, tmp_path, monkeypatch):
+        ref_file = tmp_path / "demo-technique.json"
+        ref_file.write_text(json.dumps({
+            "key_facts": ["Fact A", "Fact B"],
+            "forbidden_claims": ["Lie 1"],
+        }))
+        monkeypatch.setattr("pipeline.judge_tools.REFERENCE_DIR", tmp_path)
+        result = lookup_reference("demo-technique")
+        assert result["found"] is True
+        assert result["key_facts"] == ["Fact A", "Fact B"]
+        assert result["forbidden_claims"] == ["Lie 1"]
+
+    def test_rejects_empty(self):
+        assert "error" in lookup_reference("")
+
+
+class TestVerifyImports:
+    def test_allowed_library(self):
+        # Use stdlib modules so the test passes regardless of optional deps
+        result = verify_imports(["math", "json"])
+        assert result["passed"] is True
+        assert result["blocked"] == []
+        assert result["missing"] == []
+
+    def test_blocked_library(self):
+        result = verify_imports(["requests"])  # not in allowlist
+        assert result["passed"] is False
+        assert "requests" in result["blocked"]
+
+    def test_rejects_non_list(self):
+        # type: ignore[arg-type]
+        assert "error" in verify_imports("numpy")  # type: ignore[arg-type]
+
+
+class TestDispatch:
+    def test_routes_known_tool(self):
+        result = dispatch_tool("run_python_code", {"code": "print('ok')"})
+        assert result["passed"] is True
+
+    def test_unknown_tool(self):
+        result = dispatch_tool("not_a_tool", {})
+        assert "Unknown tool" in result["error"]
+
+    def test_bad_arguments(self):
+        result = dispatch_tool("run_python_code", {"wrong_arg": "x"})
+        assert "Bad arguments" in result["error"]
+
+    def test_tool_exception_swallowed(self):
+        original = TOOL_REGISTRY["check_equation"]["function"]
+        TOOL_REGISTRY["check_equation"]["function"] = MagicMock(
+            side_effect=RuntimeError("boom")
+        )
+        try:
+            result = dispatch_tool("check_equation", {"latex": "x"})
+            assert "RuntimeError" in result["error"]
+        finally:
+            TOOL_REGISTRY["check_equation"]["function"] = original
+
+
+class TestToolDeclarations:
+    def test_lists_all_tools(self):
+        decls = tool_declarations()
+        names = {d["name"] for d in decls}
+        assert names == {
+            "run_python_code",
+            "check_equation",
+            "lookup_reference",
+            "verify_imports",
+        }
+
+    def test_each_has_required_fields(self):
+        for decl in tool_declarations():
+            assert decl["name"]
+            assert decl["description"]
+            assert decl["parameters"]["type"] == "object"
+
+
+class TestEvaluateArtifactWithTools:
+    """End-to-end: evaluate_artifact uses generate_with_tools when available."""
+
+    def _build_mock_provider(self, loop_result):
+        provider = MagicMock()
+        provider.generate_with_tools = MagicMock(return_value=loop_result)
+        return provider
+
+    def test_passes_through_tool_calls(self):
+        judge_payload = {
+            "passed": True,
+            "overall_score": 8,
+            "criteria_scores": {
+                "factual_accuracy": 8,
+                "math_correctness": 8,
+                "clarity": 8,
+                "code_quality": 8,
+            },
+            "critiques": [],
+            "revision_instructions": [],
+        }
+        loop_result = {
+            "text": json.dumps(judge_payload),
+            "tool_calls": [
+                {
+                    "name": "run_python_code",
+                    "args": {"code": "print(1)"},
+                    "result": {"passed": True, "stdout": "1\n"},
+                    "iteration": 1,
+                }
+            ],
+            "iterations": 2,
+        }
+        provider = self._build_mock_provider(loop_result)
+
+        with patch("pipeline.judge.get_provider", return_value=provider):
+            result = evaluate_artifact(
+                "uct-upper-confidence-bounds-for-trees",
+                "implementation",
+                {"markdown": "stub", "python_examples": ["print(1)"]},
+            )
+
+        assert result["passed"] is True
+        assert result["overall_score"] == 8
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["name"] == "run_python_code"
+        assert result["iterations"] == 2
+
+    def test_handles_unparseable_text(self):
+        provider = self._build_mock_provider({
+            "text": "I cannot decide.",
+            "tool_calls": [],
+            "iterations": 1,
+        })
+        with patch("pipeline.judge.get_provider", return_value=provider):
+            result = evaluate_artifact(
+                "uct-upper-confidence-bounds-for-trees",
+                "overview",
+                {"summary": "x"},
+            )
+        assert result["passed"] is False
+        assert "did not return valid JSON" in result["critiques"][0]
+
+    def test_handles_schema_invalid_json(self):
+        provider = self._build_mock_provider({
+            "text": json.dumps({"passed": "yes"}),  # wrong types
+            "tool_calls": [],
+            "iterations": 1,
+        })
+        with patch("pipeline.judge.get_provider", return_value=provider):
+            result = evaluate_artifact(
+                "uct-upper-confidence-bounds-for-trees",
+                "overview",
+                {"summary": "x"},
+            )
+        assert result["passed"] is False
+        assert "schema validation" in result["critiques"][0]
+
+    def test_extracts_json_from_fenced_block(self):
+        judge_payload = {
+            "passed": False,
+            "overall_score": 3,
+            "criteria_scores": {
+                "factual_accuracy": 3,
+                "math_correctness": 3,
+                "clarity": 3,
+                "code_quality": 3,
+            },
+            "critiques": ["Missing math"],
+            "revision_instructions": ["Add LaTeX"],
+        }
+        loop_result = {
+            "text": f"Here is my evaluation:\n```json\n{json.dumps(judge_payload)}\n```",
+            "tool_calls": [],
+            "iterations": 1,
+        }
+        provider = self._build_mock_provider(loop_result)
+        with patch("pipeline.judge.get_provider", return_value=provider):
+            result = evaluate_artifact(
+                "uct-upper-confidence-bounds-for-trees",
+                "math_deep_dive",
+                {"markdown": "x"},
+            )
+        assert result["passed"] is False
+        assert result["overall_score"] == 3
+
+    def test_legacy_path_when_use_tools_false(self):
+        provider = MagicMock()
+        provider.generate.return_value = {
+            "passed": True,
+            "overall_score": 9,
+            "criteria_scores": {},
+            "critiques": [],
+            "revision_instructions": [],
+        }
+        # Provider must NOT have generate_with_tools called
+        with patch("pipeline.judge.get_provider", return_value=provider), \
+             patch("pipeline.judge.load_reference", return_value=None):
+            result = evaluate_artifact(
+                "uct-upper-confidence-bounds-for-trees",
+                "overview",
+                {"summary": "x"},
+                use_tools=False,
+            )
+        assert result["passed"] is True
+        assert result["tool_calls"] == []
+        provider.generate.assert_called()
+
+
+class TestGenerateWithToolsLoop:
+    """Verify the GeminiProvider tool-use loop dispatches correctly."""
+
+    def _make_provider(self):
+        from pipeline.llm_client import GeminiProvider
+
+        with patch.dict("os.environ", {"GEMINI_API_KEY": "fake"}), \
+             patch("pipeline.llm_client.genai") as mock_genai:
+            mock_client = MagicMock()
+            mock_genai.Client.return_value = mock_client
+            provider = GeminiProvider(model="gemini-test", api_key_env="GEMINI_API_KEY")
+            return provider, mock_client
+
+    def _make_response(self, *, text=None, function_calls=None):
+        candidate = MagicMock()
+        parts = []
+        if function_calls:
+            for name, args in function_calls:
+                p = MagicMock()
+                p.text = None
+                fc = MagicMock()
+                fc.name = name
+                fc.args = args
+                p.function_call = fc
+                parts.append(p)
+        if text:
+            p = MagicMock()
+            p.text = text
+            p.function_call = None
+            parts.append(p)
+        candidate.content.parts = parts
+        response = MagicMock()
+        response.candidates = [candidate]
+        return response
+
+    def test_terminates_on_text_only_response(self):
+        provider, mock_client = self._make_provider()
+        mock_client.models.generate_content.return_value = self._make_response(
+            text='{"final": true}'
+        )
+        dispatch = MagicMock()
+        result = provider.generate_with_tools(
+            system_prompt="sys",
+            user_prompt="user",
+            tools=tool_declarations(),
+            dispatch=dispatch,
+        )
+        assert result["text"] == '{"final": true}'
+        assert result["tool_calls"] == []
+        assert result["iterations"] == 1
+        dispatch.assert_not_called()
+
+    def test_dispatches_function_call_then_finalizes(self):
+        provider, mock_client = self._make_provider()
+        mock_client.models.generate_content.side_effect = [
+            self._make_response(function_calls=[("run_python_code", {"code": "print(1)"})]),
+            self._make_response(text='{"score": 7}'),
+        ]
+        dispatch = MagicMock(return_value={"passed": True, "stdout": "1\n"})
+        result = provider.generate_with_tools(
+            system_prompt="sys",
+            user_prompt="user",
+            tools=tool_declarations(),
+            dispatch=dispatch,
+        )
+        dispatch.assert_called_once_with("run_python_code", {"code": "print(1)"})
+        assert result["text"] == '{"score": 7}'
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["name"] == "run_python_code"
+        assert result["iterations"] == 2
+
+    def test_respects_max_iterations(self):
+        provider, mock_client = self._make_provider()
+        mock_client.models.generate_content.return_value = self._make_response(
+            function_calls=[("run_python_code", {"code": "x"})]
+        )
+        dispatch = MagicMock(return_value={"passed": False})
+        result = provider.generate_with_tools(
+            system_prompt="sys",
+            user_prompt="user",
+            tools=tool_declarations(),
+            dispatch=dispatch,
+            max_iterations=3,
+        )
+        assert result["iterations"] == 3
+        assert result.get("max_iterations_reached") is True
+        assert dispatch.call_count == 3

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -9,13 +9,18 @@ from pipeline.llm_client import get_provider, generate_with_retry, load_config
 
 
 class TestProviderRouting:
-    def test_plan_uses_gemini(self):
+    def test_plan_uses_gemini_flash(self):
         config = load_config()
-        assert config["artifact_provider_map"]["plan"] == "gemini"
+        assert config["artifact_provider_map"]["plan"] == "gemini_flash"
 
-    def test_overview_uses_gemini(self):
+    def test_overview_uses_gemini_flash(self):
         config = load_config()
-        assert config["artifact_provider_map"]["overview"] == "gemini"
+        assert config["artifact_provider_map"]["overview"] == "gemini_flash"
+
+    def test_judge_uses_gemini_pro(self):
+        config = load_config()
+        assert config["artifact_provider_map"]["judge"] == "gemini"
+        assert "pro" in config["providers"]["gemini"]["model"]
 
     def test_infographic_image_uses_nano_banana(self):
         config = load_config()


### PR DESCRIPTION
Routes generator artifacts to gemini-3.1-flash-preview while keeping the
judge and user-facing API endpoints on gemini-3.1-pro-preview, so the
critic loop is asymmetric (cheap producer, strong reviewer).

Upgrades the judge from a single-shot LLM call into a tool-using agent:
the judge can call run_python_code, verify_imports, check_equation, and
lookup_reference before scoring. Tool invocations are recorded in
judge_history so the evaluation logs show which checks the judge ran.

https://claude.ai/code/session_01AMAuWgXQSEsXFBGLVcZpca