### PR TITLE
Add multi-agent content orchestration pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 build/
 .pytest_cache/
 .mypy_cache/
+outputs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ OptimizationAlgorithmPortfolio/
 │   ├── math_tutor.py           # Math equation explanation endpoint
 │   └── study_plan.py           # Learning roadmap endpoint
 ├── pipeline/                   # Content generation pipeline
-│   ├── generate.py             # CLI entry point / orchestrator
+│   ├── generate.py             # CLI entry point / orchestrator (per-technique artifacts)
 │   ├── generator.py            # Artifact generation engine
 │   ├── llm_client.py           # Multi-provider LLM client (OpenAI, Gemini, Nano Banana Pro)
 │   ├── publish.py              # Static HTML publisher
@@ -45,8 +45,10 @@ OptimizationAlgorithmPortfolio/
 │   ├── validator.py            # Content validation rules
 │   ├── recommender_api.py      # Algorithm recommender endpoint
 │   ├── config.json             # Technique list, provider config, routing
-│   ├── prompts/                # Jinja2-style prompt templates (.md)
-│   └── templates/              # Jinja2 HTML templates
+│   ├── prompts/                # Prompt templates (.md, {{var}} substitution)
+│   ├── templates/              # Jinja2 HTML templates
+│   ├── agents/                 # Multi-agent content pipeline agents (intake, research, ...)
+│   └── content_pipeline/       # Multi-agent orchestrator, registry, gates, run state
 ├── tests/                      # pytest test suite (7 files, 70 tests)
 │   ├── test_generator.py       # Slugify, idempotency
 │   ├── test_llm_client.py      # Provider routing, retries
@@ -119,6 +121,7 @@ python -m pytest tests/ -k "test_valid" # Filter by name
 - **Adding a new LLM provider**: Subclass `LLMProvider` in `llm_client.py`, register in `get_provider()`, add to `config.json`
 - **Adding a new artifact type**: Add schema in `schemas.py`, prompt template in `prompts/`, validation in `validator.py`, routing in `config.json`
 - **Adding a new API endpoint**: Create blueprint in `api/`, register in `api/app.py`
+- **Adding a new content agent**: Create `pipeline/agents/<name>_agent.py` subclassing `ContentAgent`, add prompt to `pipeline/prompts/content_pipeline/`, add schema to `schemas.py`, add provider key to `config.json` `artifact_provider_map`, register in `build_default_registry()` in `pipeline/agents/__init__.py`. See `docs/content-pipeline-orchestration.md`.
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -1,88 +1,84 @@
 # Optimization Algorithm Portfolio
 
-An automated educational content platform that generates comprehensive learning materials for optimization algorithms using LLM-powered content pipelines.
+An automated educational content platform that generates comprehensive learning materials for **Monte Carlo Tree Search (MCTS) strategies and enhancements** using a multi-provider LLM pipeline, plus a multi-agent orchestration layer for arbitrary technical-content production.
+
+> The repository name reflects its origins; the active subject matter is configured in `pipeline/config.json` and is currently the MCTS Strategy Portfolio.
 
 ## Overview
 
-This project combines:
-- **LLM-driven content generation** — Automatically creates educational materials using OpenAI GPT-4o, Gemini 3.1 Pro, and Nano Banana Pro
-- **Interactive Flask API** — Real-time algorithm recommendations, comparisons, math tutoring, and code adaptation
-- **Static site publisher** — Generates a mobile-responsive educational website
+This project combines three subsystems that share the same LLM client, schema validator, and prompt-template idioms:
 
-## Features
+1. **Per-technique content pipeline** (`pipeline/generate.py`) — generates structured artifacts (plan, overview, math deep dive, implementation, infographic spec, infographic image, playground config, knowledge graph) for each technique listed in `config.json`. Idempotent, manifest-aware, and routed per-artifact to the most appropriate Gemini model.
+2. **Multi-agent content pipeline** (`pipeline/content_pipeline/` + `pipeline/agents/`) — takes an arbitrary raw input (idea, transcript, outline, or rough draft) and runs it through eight specialized agents, with quality gates between stages, structured run state on disk, and resume-by-run-id support.
+3. **Interactive Flask API** (`api/`) — serves recommender, comparison, math tutor, study plan, and code adaptation endpoints alongside the static site.
 
-### Content Generation
-- Generates structured educational content for 8 optimization algorithms
-- Creates multiple artifact types: overviews, math deep dives, implementations, and infographics
-- Schema-validated JSON output with retry logic
+## MCTS Strategies Covered
 
-### Interactive Learning Tools
-- **Algorithm Recommender** — Get personalized algorithm suggestions based on your problem description
-- **Study Plan Generator** — Create customized learning roadmaps
-- **Math Tutor** — Interactive explanations of mathematical concepts and derivations
-- **Algorithm Comparator** — Side-by-side comparison of different optimization approaches
-- **Code Adapter** — Transform implementations between frameworks (NumPy, PyTorch, JAX, etc.)
+The eight techniques currently configured in `pipeline/config.json`:
 
-### Educational Website
-- Mobile-responsive design with modern UI
-- Expandable mathematical derivations
-- Code examples with framework tabs
-- Use-case comparison matrix
+1. **UCT** — Upper Confidence Bounds for Trees
+2. **RAVE** — Rapid Action Value Estimation
+3. **Progressive History & Progressive Widening**
+4. **NST** — N-gram Selection Technique
+5. **Rollout Policy Strategies**
+6. **Opponent Modeling in MCTS**
+7. **Root & Tree Parallelization**
+8. **Adaptive Meta-Optimization**
 
-## Optimization Techniques Covered
-
-1. **Bayesian Optimization** — Probabilistic surrogate-based optimization
-2. **Genetic Algorithm** — Evolutionary computation inspired by natural selection
-3. **Simulated Annealing** — Probabilistic technique for approximating global optima
-4. **Particle Swarm Optimization** — Swarm intelligence optimization
-5. **Gradient Descent** — First-order iterative optimization
-6. **Nelder-Mead Simplex** — Derivative-free simplex method
-7. **CMA-ES** — Covariance Matrix Adaptation Evolution Strategy
-8. **Differential Evolution** — Stochastic population-based optimizer
+The list is configuration-driven. Retargeting the portfolio to a different domain is a `config.json` change — see `pipeline/generate.py` and `pipeline/config.json`.
 
 ## Quick Start
 
 ### Prerequisites
+
 - Python 3.11+
-- OpenAI API key
-- Google Gemini API key
+- Google Gemini API key (`GEMINI_API_KEY`) — used for all text and image generation
 
 ### Installation
 
 ```bash
-# Clone the repository
 git clone https://github.com/TGALLOWAY1/OptimizationAlgorithmPortfolio.git
 cd OptimizationAlgorithmPortfolio
 
-# Create virtual environment
 python3.11 -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-
-# Install dependencies
+source .venv/bin/activate            # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 
-# Configure API keys
-cat > .env << EOF
-OPENAI_API_KEY=sk-your-key-here
+cat > .env << 'EOF'
 GEMINI_API_KEY=your-gemini-key-here
 EOF
 ```
 
-### Generate Content
+### Generate Per-Technique Content
 
 ```bash
-# Generate all techniques
+# Generate every configured technique
 python3.11 -m pipeline.generate
 
 # Generate a single technique
-python3.11 -m pipeline.generate --technique "Bayesian Optimization"
+python3.11 -m pipeline.generate --technique "UCT (Upper Confidence Bounds for Trees)"
 
 # Skip image generation (faster, lower cost)
 python3.11 -m pipeline.generate --skip-images
 
-# Remove stale generated outputs before regenerating
-python3.11 -m pipeline.generate --clean
+# Force regeneration of cached artifacts
+python3.11 -m pipeline.generate --force
 ```
+
+### Run the Multi-Agent Content Pipeline
+
+```bash
+# Smoke run with stub agents (no API key required)
+python3.11 examples/run_content_pipeline.py --dry-run
+
+# Real run (uses GEMINI_API_KEY)
+python3.11 examples/run_content_pipeline.py --input examples/sample_input.json
+
+# Resume an interrupted run by id
+python3.11 examples/run_content_pipeline.py --resume <run_id>
+```
+
+Outputs land under `outputs/runs/<run_id>/` (gitignored).
 
 ### Publish Static Site
 
@@ -93,159 +89,170 @@ python3.11 -m pipeline.publish
 ### Run the Application
 
 ```bash
-# Start Flask server (serves both API and static site)
 python3.11 api/app.py
-
-# Open http://localhost:5000 in your browser
+# Open http://localhost:5000
 ```
 
 ## API Endpoints
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/recommend` | POST | Get algorithm recommendations for a problem |
-| `/api/compare` | POST | Compare two algorithms side-by-side |
-| `/api/math_tutor` | POST | Get explanations for math concepts |
-| `/api/study_plan` | POST | Generate a personalized study plan |
-| `/api/adapt_code` | POST | Adapt code between frameworks |
+| Endpoint              | Method | Description                                        |
+| --------------------- | ------ | -------------------------------------------------- |
+| `/api/recommend`      | POST   | Get algorithm recommendations for a problem        |
+| `/api/compare`        | POST   | Compare two algorithms side-by-side                |
+| `/api/math_tutor`     | POST   | Get explanations for math concepts (SSE streaming) |
+| `/api/study_plan`     | POST   | Generate a personalized study plan (SSE streaming) |
+| `/api/adapt_code`     | POST   | Adapt code between frameworks                      |
 
 ### Example: Algorithm Recommendation
 
 ```bash
 curl -X POST http://localhost:5000/api/recommend \
   -H "Content-Type: application/json" \
-  -d '{"query": "I need to tune hyperparameters for a neural network with expensive evaluations"}'
+  -d '{"query": "I need a selection policy that handles high branching factors with limited rollouts"}'
 ```
+
+## Architecture
+
+### Multi-Model LLM Routing
+
+All requests are routed through `pipeline.llm_client.get_provider(artifact_type)`, which reads `pipeline/config.json`'s `artifact_provider_map` and returns the right provider instance. Three Gemini-family models are wired up; the assignment is deliberately asymmetric — flagship reasoning where it matters, cheap flash everywhere else, and the image model only for visual artifacts.
+
+| Provider key   | Model                              | Role                                                                                          |
+| -------------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `gemini`       | `gemini-3.1-pro-preview`           | High-stakes reasoning: drafting, technical review, editor, recommender, judge, math tutor, comparator, study plan, code adapter. |
+| `gemini_flash` | `gemini-3.1-flash-preview`         | Bulk generation: per-technique plans, overviews, math deep dives, implementations, infographic specs, homepage summaries, knowledge graph, playground configs, intake/research/outline/repurposing/QA agents. |
+| `nano_banana`  | `gemini-3.1-flash-image-preview`   | Image generation: infographic and preview images.                                              |
+
+Adding a new provider is a three-step change: subclass `LLMProvider` in `pipeline/llm_client.py`, register it in `get_provider()`, and add an entry under `providers` and `artifact_provider_map` in `config.json`.
+
+### Per-Technique Content Pipeline
+
+`pipeline/generate.py` is the orchestrator for the technique-content axis:
+
+1. **Config-driven** — `config.json` lists techniques and maps each artifact type to a provider.
+2. **Manifest-aware idempotency** — `manifest.json` per technique tracks the input hash (prompt + schema + config slice + technique inputs). Artifacts regenerate only when an input changes or `--force` is set.
+3. **Strict schemas** — every JSON artifact is validated against a schema in `pipeline/schemas.py` after generation, with an additional content-validation pass in `pipeline/validator.py` (word counts, LaTeX presence, technique-term coverage, off-topic detection).
+4. **Exponential-backoff retry** — `generate_with_retry` retries up to three times (2s, 4s, 8s) on API failures and schema-validation failures.
+5. **Generated/source split** — `content/` holds tracked source data (references, rubrics); `generated/` holds runtime outputs (gitignored); `site/` holds published HTML (gitignored).
+
+### Multi-Agent Content Pipeline
+
+A separate orchestration layer (`pipeline/content_pipeline/` + `pipeline/agents/`) runs an arbitrary raw input through eight specialized agents with quality gates between stages. Every step writes a typed JSON artifact to disk; failed gates trigger a bounded revision pass; interrupted runs can be resumed by run id.
+
+```
+ContentPipelineInput
+       │
+       ▼
+   ┌─────────┐    ┌──────────┐    ┌─────────┐    ┌─────────┐
+   │ intake  │───▶│ research │───▶│ outline │───▶│  draft  │
+   └─────────┘    └──────────┘    └─────────┘    └─────────┘
+   intake_gate                    outline_gate   draft_gate
+       │                                │             │
+       ▼                                ▼             ▼
+   ┌──────────────────┐    ┌────────┐    ┌─────────────┐    ┌──────────────┐
+   │ technical_review │───▶│ editor │───▶│ repurposing │───▶│ publishing_qa│
+   └──────────────────┘    └────────┘    └─────────────┘    └──────────────┘
+   tech_review_gate                        (optional)         final_qa_gate
+                                                              (optional)
+```
+
+#### Agent roles
+
+| Stage              | Agent                       | Responsibility                                                                                                                                                          | Provider key            |
+| ------------------ | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `intake`           | **Intake Agent**            | Parses the user's raw input (idea, transcript, outline, draft) and extracts a normalized `ContentBrief`: topic, audience, content type, technical depth, goals, requested artifacts. | `agent_intake` (Flash)  |
+| `research`         | **Research Agent**          | Surfaces the claims a piece needs to support, marks each claim's `needs_verification` flag, and lists assumptions and open questions. (No live web access — claims that depend on external sources are flagged for human verification.) | `agent_research` (Flash)|
+| `outline`          | **Outline Agent**           | Converts brief + research into a structured outline with title, hook, ordered sections, per-section purpose and key points, target word count, and target format.       | `agent_outline` (Flash) |
+| `draft`            | **Drafting Agent**          | Produces the first full Markdown draft, using the outline as the source of truth, matching audience and depth from the brief. Refuses placeholder text.                  | `agent_draft` (Pro)     |
+| `technical_review` | **Technical Reviewer Agent**| Reads the draft as a careful senior engineer would: flags inaccuracies, vague claims, missing steps, unsupported assumptions. Returns issues with explicit severity (`critical/major/minor/nit`). Does not rewrite prose. | `agent_technical_review` (Pro) |
+| `editor`           | **Editor Agent**            | Improves clarity, structure, transitions, concision, and tone while preserving every load-bearing technical claim. Resolves reviewer issues and reports the edits made.  | `agent_editor` (Pro)    |
+| `repurposing`      | **Repurposing Agent**       | Converts the edited long-form into channel-specific assets: LinkedIn post, X thread, YouTube description, short-form video script, newsletter blurb, README excerpt. Each asset matches its channel's voice and length conventions. *(Optional stage — failures are recorded as `skipped`, not `failed`.)* | `agent_repurposing` (Flash) |
+| `publishing_qa`    | **Publishing QA Agent**     | Final gate before shipping. Reads the edited long-form and the repurposed assets together; flags missing sections, broken formatting, overclaiming, weak hooks, missing CTAs, terminology drift, completeness issues. Produces a 0–100 QA score and a `publishable` boolean. *(Optional stage.)* | `agent_publishing_qa` (Flash) |
+
+#### Quality gates
+
+Five gates run between stages. A gate failure marks the stage `needs_revision`, feeds the gate's failures back to the agent as additional context, and re-runs the agent up to `max_revisions` times (default 1). When the budget is exhausted, the pipeline fails for required stages or skips the stage for optional ones.
+
+| Gate                | After stage        | Pass condition                                                                  |
+| ------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| `intake_gate`       | `intake`           | Brief has audience, content_type, goals, topic                                  |
+| `outline_gate`      | `outline`          | Title + hook present, ≥3 sections, at least one `explanation`/`deep_dive`       |
+| `draft_gate`        | `draft`            | ≥300 words, no `TODO`/`TBD`/`[placeholder]` markers, ≥80% outline coverage      |
+| `tech_review_gate`  | `technical_review` | No critical-severity issues unresolved                                          |
+| `final_qa_gate`     | `publishing_qa`    | `publishable: true` and `qa_score >= 60`                                        |
+
+#### State and persistence
+
+Every transition writes `outputs/runs/<run_id>/run.json` atomically (tmp file + `os.replace`). Pipeline statuses: `queued`, `running`, `waiting_for_review`, `failed`, `completed`, `cancelled`. Stage statuses: `pending`, `running`, `succeeded`, `failed`, `skipped`, `needs_revision`. Resume reads back already-succeeded stages and replays only the rest.
+
+See [`docs/content-pipeline-orchestration.md`](docs/content-pipeline-orchestration.md) for the full architecture, data contracts, and instructions for adding a new agent.
 
 ## Project Structure
 
 ```
 OptimizationAlgorithmPortfolio/
-├── api/                        # Flask API blueprints
-│   ├── app.py                  # Main app, serves API + static site
-│   ├── adapt_code.py           # Code adaptation endpoint
-│   ├── compare.py              # Algorithm comparison endpoint
-│   ├── math_tutor.py           # Math tutoring endpoint
-│   └── study_plan.py           # Study plan generation endpoint
-├── pipeline/                   # Content generation pipeline
-│   ├── generate.py             # CLI orchestrator
-│   ├── generator.py            # Artifact generation engine
-│   ├── llm_client.py           # Multi-provider LLM client
-│   ├── publish.py              # Static HTML publisher
-│   ├── schemas.py              # JSON Schema definitions
-│   ├── prompts/                # Prompt templates
-│   └── templates/              # Jinja2 HTML templates
-├── tests/                      # Test suite (70 tests)
-├── content/                    # Tracked source data (references + rubrics)
-├── generated/                  # Generated technique artifacts, matrix, and evaluation outputs
-├── site/                       # Published HTML (gitignored)
-├── requirements.txt            # Python dependencies
-├── SETUP.md                    # Detailed setup instructions
-└── CLAUDE.md                   # Codebase documentation
+├── api/                                # Flask API blueprints
+│   ├── app.py                          # App factory + static-site serving
+│   ├── adapt_code.py
+│   ├── compare.py
+│   ├── math_tutor.py
+│   └── study_plan.py
+├── pipeline/                           # Content generation pipeline
+│   ├── generate.py                     # Per-technique CLI orchestrator
+│   ├── generator.py                    # Per-technique artifact engine
+│   ├── llm_client.py                   # LLMProvider ABC, Gemini + Nano Banana providers, retry
+│   ├── publish.py                      # Static HTML publisher
+│   ├── schemas.py                      # JSON Schema definitions
+│   ├── validator.py                    # Content validation rules
+│   ├── recommender_api.py              # Recommender Flask app
+│   ├── config.json                     # Topic, techniques, providers, artifact routing
+│   ├── prompts/                        # Prompt templates ({{var}} substitution)
+│   │   └── content_pipeline/           # Multi-agent prompt templates
+│   ├── templates/                      # Jinja2 HTML templates
+│   ├── agents/                         # 8 ContentAgent subclasses + base ABC + default registry
+│   └── content_pipeline/               # Orchestrator, registry, gates, state, history
+├── examples/
+│   ├── run_content_pipeline.py         # Multi-agent pipeline CLI (incl. --dry-run)
+│   └── sample_input.json
+├── docs/
+│   └── content-pipeline-orchestration.md
+├── tests/                              # 226 tests, all LLM calls mocked
+├── content/                            # Tracked source data (references, rubrics)
+├── generated/                          # Per-technique outputs (gitignored)
+├── outputs/                            # Multi-agent pipeline runs (gitignored)
+├── site/                               # Published HTML (gitignored)
+├── requirements.txt
+├── SETUP.md
+└── CLAUDE.md
 ```
-
-## Architecture
-
-### Multi-Provider LLM Routing
-
-The pipeline routes different artifact types to appropriate LLM providers:
-
-| Provider | Use Case |
-|----------|----------|
-| OpenAI GPT-4o | Complex content (overviews, math deep dives) |
-| Gemini 3.1 Pro | Structured content (plans, implementations) |
-| Nano Banana Pro | Image generation (infographics) |
-
-### Content Pipeline
-
-1. **Config-driven** — `config.json` maps techniques to providers
-2. **Manifest-aware invalidation** — Artifacts regenerate when prompts, schemas, config, or artifact version change
-3. **Generated/source split** — Tracked `content/` files stay as source data; runtime outputs live under `generated/`
-4. **Schema-validated** — All JSON outputs validated against strict schemas
-5. **Retry logic** — Exponential backoff for API calls
-
-### Multi-Agent Content Pipeline
-
-A separate orchestration layer (`pipeline/content_pipeline/`) takes an arbitrary raw input — idea, transcript, outline, or rough draft — and runs it through eight specialized agents (intake → research → outline → draft → technical review → edit → repurposing → publishing QA) with quality gates between stages. Every step writes a typed artifact to disk; failed gates trigger a bounded revision pass; interrupted runs can be resumed by run id.
-
-```bash
-# Smoke run with stub agents (no API key required)
-python examples/run_content_pipeline.py --dry-run
-
-# Real run (needs GEMINI_API_KEY)
-python examples/run_content_pipeline.py --input examples/sample_input.json
-```
-
-See [`docs/content-pipeline-orchestration.md`](docs/content-pipeline-orchestration.md) for the architecture, agent contracts, and instructions for adding a new agent.
 
 ## Testing
 
 ```bash
-# Run all tests (no API keys required — all LLM calls are mocked)
-python3.11 -m pytest tests/ -v
+# Full suite
+python3.11 -m pytest tests/ -q
 
-# Run specific test file
-python3.11 -m pytest tests/test_api_endpoints.py -v
+# Multi-agent pipeline tests only
+python3.11 -m pytest tests/test_content_agents.py tests/test_quality_gates.py tests/test_content_pipeline.py -v
 
-# Run with coverage
-python3.11 -m pytest tests/ --cov=pipeline --cov=api
+# Filter by name
+python3.11 -m pytest tests/ -k "schema" -v
 ```
+
+All tests use `unittest.mock` — no API keys or network calls are required. The 37 multi-agent tests cover happy path, hard failure, optional-stage skip, gate-driven revision, gate budget exhaustion, and resume-from-run-id.
 
 ## Cost Estimates
 
-Full pipeline run (8 techniques, generated content + images):
+Full per-technique content refresh:
 
-| Provider | Artifacts | Est. Cost |
-|----------|-----------|-----------|
-| Gemini 3.1 Pro | Plans, technique content, homepage summaries, use-case matrix | ~$3-8 |
-| Nano Banana Pro | Infographic + preview images | ~$1-3 |
-| **Total** | **Full content refresh** | **~$4-11** |
+| Provider          | Artifacts                                                                  | Est. Cost |
+| ----------------- | -------------------------------------------------------------------------- | --------- |
+| Gemini 3.1 Flash  | Plans, overviews, math deep dives, implementations, infographic specs, summaries, knowledge graph, playground configs | ~$3–8     |
+| Gemini 3.1 Pro    | Recommender, judge, math tutor, comparator, study plan, code adapter        | ~$0.50–2  |
+| Nano Banana Pro   | Infographic + preview images                                                | ~$1–3     |
+| **Total**         | **Full content refresh**                                                    | **~$4–13**|
 
-Use `--skip-images` during development to reduce costs.
-
-## Manual Verification Checklist
-
-After generating content and publishing the site, verify these features manually:
-
-### SSE Streaming (Feature 1)
-- [ ] Open a technique page (e.g., `gradient-descent.html`)
-- [ ] In the **Mathematical Deep Dive** section, select an equation and click "Explain this"
-- [ ] Verify the Math Tutor sidebar opens and text streams in token-by-token (not all at once)
-- [ ] Verify KaTeX renders math correctly after streaming completes
-- [ ] On the homepage, open the **Study Plan** modal, fill in background and goals, and click "Generate Plan"
-- [ ] Verify the loading text animates ("Generating your study plan...", dots cycle)
-- [ ] Verify the study plan timeline renders correctly after streaming finishes
-
-### Knowledge Graph (Feature 2)
-- [ ] On the homepage (`index.html`), verify the **Algorithm Relationship Map** section appears
-- [ ] Verify all 8 algorithm nodes are visible as colored circles
-- [ ] Verify nodes are color-coded by category (red=evolutionary, blue=gradient-based, green=probabilistic, orange=direct-search)
-- [ ] Drag a node — verify the physics simulation responds (other nodes adjust)
-- [ ] Hover a node — verify a tooltip appears showing the algorithm name and summary
-- [ ] Hover a node — verify connected edges are highlighted
-- [ ] Click a node — verify it navigates to the correct technique page
-- [ ] Verify the legend at the bottom shows all 4 categories
-- [ ] Resize the browser window — verify the graph adjusts responsively
-
-### Algorithm Playground (Feature 3)
-- [ ] Open a technique page (e.g., `gradient-descent.html`)
-- [ ] Verify the **Interactive Playground** section appears below Implementation
-- [ ] Verify parameter sliders are present and labeled correctly
-- [ ] Verify the contour plot renders on the dark canvas (color gradient visible)
-- [ ] Click **Play** — verify the algorithm animates on the contour plot
-- [ ] Click **Pause** — verify the animation stops
-- [ ] Click **Step** — verify a single iteration executes
-- [ ] Click **Reset** — verify the state resets (trail cleared, iteration counter resets)
-- [ ] Adjust a parameter slider — verify the value label updates
-- [ ] Verify the **Iteration** and **Best** stats update during animation
-- [ ] Check `genetic-algorithm.html` — verify population dots (scatter) instead of single trajectory
-- [ ] Check `nelder-mead-simplex.html` — verify simplex triangle is drawn
-- [ ] Check `particle-swarm-optimization.html` — verify multiple particles move with a highlighted global best
-
-### Cross-Cutting
-- [ ] Run `python -m pytest tests/ -v` — verify all 155 tests pass
-- [ ] Open the site on mobile (or use browser devtools responsive mode) — verify all features are usable
-- [ ] Verify no console errors in browser developer tools on homepage and technique pages
+Use `--skip-images` during development to reduce costs. The multi-agent pipeline costs roughly $0.50–2 per run depending on input length.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ The pipeline routes different artifact types to appropriate LLM providers:
 4. **Schema-validated** — All JSON outputs validated against strict schemas
 5. **Retry logic** — Exponential backoff for API calls
 
+### Multi-Agent Content Pipeline
+
+A separate orchestration layer (`pipeline/content_pipeline/`) takes an arbitrary raw input — idea, transcript, outline, or rough draft — and runs it through eight specialized agents (intake → research → outline → draft → technical review → edit → repurposing → publishing QA) with quality gates between stages. Every step writes a typed artifact to disk; failed gates trigger a bounded revision pass; interrupted runs can be resumed by run id.
+
+```bash
+# Smoke run with stub agents (no API key required)
+python examples/run_content_pipeline.py --dry-run
+
+# Real run (needs GEMINI_API_KEY)
+python examples/run_content_pipeline.py --input examples/sample_input.json
+```
+
+See [`docs/content-pipeline-orchestration.md`](docs/content-pipeline-orchestration.md) for the architecture, agent contracts, and instructions for adding a new agent.
+
 ## Testing
 
 ```bash

--- a/docs/content-pipeline-orchestration.md
+++ b/docs/content-pipeline-orchestration.md
@@ -1,0 +1,134 @@
+# Multi-Agent Content Pipeline
+
+A staged orchestration layer that turns a raw input — an idea, transcript, outline, research note, or rough draft — into a polished long-form artifact plus channel-specific derivatives. It composes eight specialized agents with quality gates between them, persists every step to disk, and supports resuming an interrupted run.
+
+This system is independent of `pipeline.generate`, which orchestrates per-technique artifact generation for the optimization-algorithm site. Both share the same LLM client, JSON Schema validation, prompt-template idioms, and provider-routing config.
+
+## Pipeline shape
+
+```
+ContentPipelineInput
+        │
+        ▼
+   ┌─────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐
+   │ intake  │───▶│research │───▶│ outline │───▶│  draft  │
+   └────┬────┘    └─────────┘    └────┬────┘    └────┬────┘
+   intake_gate                  outline_gate   draft_gate
+        │                            │              │
+        ▼                            ▼              ▼
+   ┌─────────────────┐    ┌─────────┐    ┌─────────────┐    ┌──────────────┐
+   │technical_review │───▶│ editor  │───▶│ repurposing │───▶│publishing_qa │
+   └─────────────────┘    └─────────┘    └─────────────┘    └──────────────┘
+   tech_review_gate                       (optional)         final_qa_gate
+                                                              (optional)
+```
+
+## Agent responsibilities
+
+| Stage              | Agent                         | Input                                  | Output (schema)         | Provider key            |
+| ------------------ | ----------------------------- | -------------------------------------- | ----------------------- | ----------------------- |
+| `intake`           | `IntakeAgent`                 | raw input + hints                      | `content_brief`         | `agent_intake`          |
+| `research`         | `ResearchAgent`               | brief                                  | `research_notes`        | `agent_research`        |
+| `outline`          | `OutlineAgent`                | brief + research                       | `content_outline`       | `agent_outline`         |
+| `draft`            | `DraftingAgent`               | outline + brief + research             | `draft`                 | `agent_draft`           |
+| `technical_review` | `TechnicalReviewerAgent`      | draft + brief + research               | `review_report`         | `agent_technical_review`|
+| `editor`           | `EditorAgent`                 | draft + review + brief                 | `edited_draft`          | `agent_editor`          |
+| `repurposing`      | `RepurposingAgent` (optional) | edited draft + outline + brief         | `repurposed_assets`     | `agent_repurposing`     |
+| `publishing_qa`    | `PublishingQAAgent` (optional)| edited draft + repurposed + outline    | `publishing_qa`         | `agent_publishing_qa`   |
+
+Provider mapping lives in `pipeline/config.json` under `artifact_provider_map`. Drafting and reviewing route to the Pro model; everything else uses Flash.
+
+## Quality gates
+
+| Gate                | After stage        | Pass condition                                                                  |
+| ------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| `intake_gate`       | `intake`           | brief has audience, content_type, goals, topic                                  |
+| `outline_gate`      | `outline`          | title + hook present, ≥3 sections, at least one `explanation`/`deep_dive`       |
+| `draft_gate`        | `draft`            | ≥300 words, no `TODO`/`TBD`/`[placeholder]` markers, ≥80% outline coverage      |
+| `tech_review_gate`  | `technical_review` | no critical-severity issues unresolved                                          |
+| `final_qa_gate`     | `publishing_qa`    | `publishable: true` and `qa_score >= 60`                                        |
+
+When a gate fails, the orchestrator marks the stage `needs_revision`, appends the gate's failures to `PipelineContext.gate_feedback`, and re-runs the same agent up to `max_revisions` times (default 1). When the budget is exhausted: required stages mark the pipeline `failed`; optional stages are recorded as `skipped`.
+
+## Data contracts
+
+Every JSON Schema for the contracts above is registered in `pipeline.schemas.SCHEMAS`:
+
+- `content_brief`, `research_notes`, `content_outline`, `draft`, `review_report`, `edited_draft`, `repurposed_assets`, `publishing_qa`.
+
+Payloads stay as plain dicts validated by `jsonschema` — the same convention as every other artifact in the repo. Orchestration internals (`StageRun`, `ContentPipelineRun`, `AgentResult`, `AgentMetadata`, `QualityGateResult`, `PipelineContext`) are `@dataclass` types in `pipeline/content_pipeline/state.py` and `pipeline/agents/base.py`.
+
+## Pipeline & stage statuses
+
+`PipelineStatus`: `queued`, `running`, `waiting_for_review`, `failed`, `completed`, `cancelled`.
+`StageStatus`: `pending`, `running`, `succeeded`, `failed`, `skipped`, `needs_revision`.
+
+The `cancelled` status is reserved for a future external-cancellation mechanism; `ContentPipeline.cancel()` raises `NotImplementedError`. The `waiting_for_review` status is set when `auto_approve=False` and the technical reviewer flags `requires_human: true` — the run pauses and can be resumed later.
+
+## Failure handling and resume
+
+Every stage transition writes `outputs/runs/<run_id>/run.json` atomically (tmp file + `os.replace`). On a partial failure or interruption you can resume:
+
+```bash
+python examples/run_content_pipeline.py --resume <run_id>
+```
+
+The orchestrator scans the loaded run for stages already marked `succeeded` with their JSON output present on disk and skips them, replaying only the remaining stages.
+
+## How to run the example
+
+```bash
+# Smoke test with stub agents (no API key required)
+python examples/run_content_pipeline.py --dry-run --input examples/sample_input.json
+
+# Real run (needs GEMINI_API_KEY; ~$0.50–2 in tokens)
+python examples/run_content_pipeline.py --input examples/sample_input.json
+```
+
+A successful run writes the following under `outputs/runs/<run_id>/`:
+
+```
+run.json
+intake.json
+research.json
+outline.json
+draft.json          draft.md
+technical_review.json
+editor.json         edited-draft.md
+repurposing.json    linkedin-post.md
+                    x-thread.md
+                    youtube-description.md
+                    short-form-script.md
+                    newsletter-blurb.md
+                    readme-excerpt.md
+publishing_qa.json
+```
+
+## How to add a new agent
+
+1. **Schema.** Add a new JSON Schema in `pipeline/schemas.py` and register it in `SCHEMAS`.
+2. **Prompt.** Add `pipeline/prompts/content_pipeline/<your_agent>.md` with `{{var}}` placeholders.
+3. **Provider routing.** Add a key under `artifact_provider_map` in `pipeline/config.json`.
+4. **Agent class.** Create `pipeline/agents/<your_agent>.py` subclassing `ContentAgent`. Declare `STAGE_ID`, `ARTIFACT_TYPE`, `SCHEMA_KEY`, `PROMPT_FILE`. Implement `run(stage_input, context)` — typically pull required context from `context.previous_outputs`, render the prompt, call `self._call_llm`, and return `AgentResult`.
+5. **Quality gate (optional).** Add a `QualityGate` subclass in `pipeline/content_pipeline/quality_gates.py`.
+6. **Register.** Add a `StageDefinition` to the list returned by `build_default_registry()` in `pipeline/agents/__init__.py`.
+7. **Tests.** Per-agent unit tests in `tests/test_content_agents.py` (mock `pipeline.agents.base.get_provider` + `pipeline.agents.base.generate_with_retry`); gate tests in `tests/test_quality_gates.py`.
+
+## How to run the tests
+
+```bash
+# Multi-agent pipeline tests only
+python -m pytest tests/test_content_agents.py tests/test_quality_gates.py tests/test_content_pipeline.py -v
+
+# Full suite
+python -m pytest tests/ -q
+```
+
+All 37 multi-agent tests use `unittest.mock` — no API keys are needed.
+
+## Future extensions
+
+- **Live web research.** The `ResearchAgent` currently marks every claim `needs_verification: true` because the pipeline has no browse tool. The existing `LLMProvider.generate_with_tools` capability in `pipeline/llm_client.py` is the natural extension point.
+- **Cancellation.** `ContentPipeline.cancel()` is reserved for an external signal (e.g., a future API endpoint).
+- **Human-in-the-loop.** `auto_approve=False` already pauses the run after `technical_review` if the reviewer flags `requires_human`. A small Flask blueprint can expose an approval endpoint.
+- **Streaming progress.** The repo already has SSE precedents (`api/math_tutor.py` stream endpoint). The pipeline is currently synchronous; per-stage events could be streamed to a UI without changing agent contracts.

--- a/examples/run_content_pipeline.py
+++ b/examples/run_content_pipeline.py
@@ -1,0 +1,321 @@
+"""Run the multi-agent content pipeline against a sample input.
+
+Examples
+--------
+
+End-to-end smoke run with stubbed agents (no API key required)::
+
+    python examples/run_content_pipeline.py --dry-run
+
+End-to-end run against real LLMs (needs ``GEMINI_API_KEY`` set)::
+
+    python examples/run_content_pipeline.py --input examples/sample_input.json
+
+Resume a previously interrupted run::
+
+    python examples/run_content_pipeline.py --resume 20260505T120000Z-abc123
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from pipeline.agents import build_default_registry
+from pipeline.agents.base import (
+    AgentMetadata,
+    AgentResult,
+    ContentAgent,
+    PipelineContext,
+)
+from pipeline.content_pipeline.pipeline import ContentPipeline
+from pipeline.content_pipeline.quality_gates import (
+    DraftGate,
+    FinalQAGate,
+    IntakeGate,
+    OutlineGate,
+    TechnicalReviewGate,
+)
+from pipeline.content_pipeline.registry import AgentRegistry, StageDefinition
+from pipeline.content_pipeline.state import PipelineStatus
+
+DEFAULT_INPUT = Path("examples/sample_input.json")
+DEFAULT_OUTPUT_ROOT = Path("outputs/runs")
+
+
+def _stub_agent(stage_id: str, name: str, payload: dict):
+    class _Stub(ContentAgent):
+        id = stage_id
+        STAGE_ID = stage_id
+        ARTIFACT_TYPE = f"agent_{stage_id}"
+        SCHEMA_KEY = stage_id  # not used in stub
+        PROMPT_FILE = stage_id  # not used in stub
+
+        def __init__(self):
+            self.name = name
+            self.description = f"Stub {name} for --dry-run"
+
+        def run(self, stage_input, context: PipelineContext) -> AgentResult:
+            return AgentResult(
+                success=True,
+                output=payload,
+                metadata=AgentMetadata(model="stub", duration_ms=1),
+            )
+
+    return _Stub()
+
+
+def _build_dry_run_registry() -> AgentRegistry:
+    """Return a registry whose agents return canned outputs.
+
+    Each output is shaped to satisfy the corresponding schema in
+    :mod:`pipeline.schemas` and the cross-stage quality gates.
+    """
+    brief = {
+        "topic": "Multi-agent orchestration for AI-native product workflows",
+        "audience": "technical product managers and engineering leads",
+        "content_type": "blog_post",
+        "technical_depth": "intermediate",
+        "goals": [
+            "explain why one-shot LLM calls fail at production content workflows",
+            "show a concrete staged-agent pattern readers can adopt",
+        ],
+        "requested_artifacts": ["blog_post", "linkedin_post", "x_thread"],
+        "raw_input_summary": "Article comparing one-shot LLM use to a staged multi-agent pipeline.",
+        "key_terms": ["orchestration", "agents", "PRD", "pipeline"],
+    }
+    research = {
+        "notes": [
+            {
+                "claim": "One-shot LLM calls couple unrelated cognitive tasks.",
+                "supporting_points": [
+                    "research, drafting, and review have different failure modes",
+                    "single prompts cannot easily expose intermediate state",
+                ],
+                "needs_verification": False,
+            },
+            {
+                "claim": "Staged pipelines yield observable, testable artifacts.",
+                "supporting_points": [
+                    "each stage's output is a structured payload",
+                    "schemas double as contracts between stages",
+                ],
+                "needs_verification": False,
+            },
+        ],
+        "assumptions": ["readers already use LLMs day-to-day"],
+        "open_questions": ["how do teams measure staged-pipeline ROI?"],
+    }
+    sections = [
+        {
+            "heading": "The cost of one-shot LLM workflows",
+            "purpose": "Frame the problem with a concrete failure mode.",
+            "key_points": [
+                "one prompt does too much",
+                "no observability into intermediate state",
+            ],
+            "section_type": "intro",
+        },
+        {
+            "heading": "What changes when you split the work",
+            "purpose": "Walk through a staged-pipeline pattern.",
+            "key_points": [
+                "each agent owns one responsibility",
+                "schemas become contracts",
+                "quality gates block weak outputs",
+            ],
+            "section_type": "explanation",
+        },
+        {
+            "heading": "Applying it to your team",
+            "purpose": "Give the reader a starting pattern.",
+            "key_points": ["start with intake + outline", "add gates incrementally"],
+            "section_type": "cta",
+        },
+    ]
+    outline = {
+        "title": "From One-Shot to Orchestrated: A Better Way to Use LLMs in Product Work",
+        "hook": "Most teams treat LLMs as a single magic box. The teams that ship reliably split the box into stages.",
+        "sections": sections,
+        "estimated_word_count": 900,
+        "target_format": "blog_post",
+    }
+    draft_markdown = (
+        "## The cost of one-shot LLM workflows\n\n"
+        "Most teams reach for an LLM the same way they reach for a calculator: paste in a prompt, copy out a result. "
+        "That works for a quick answer. It does not work for a content workflow that has to ship reliably, week after week. "
+        "When research, drafting, and review all happen in one prompt, you cannot inspect any of them. "
+        "When the output is wrong, you cannot tell which step caused it. When you want to improve quality, you cannot target the failing layer. "
+        "One prompt is a black box; a workflow has to be observable. The black-box problem compounds at scale: the more content you ship, the more you depend on lucky outputs and the less you can debug the unlucky ones. "
+        "Teams discover this the hard way, usually when a piece slips through with a hallucinated benchmark or a confident but wrong claim, and there is nowhere to look to ask which step failed.\n\n"
+        "## What changes when you split the work\n\n"
+        "A staged pipeline names each cognitive task and gives it its own agent: intake, research, outline, draft, review, edit, repurpose, QA. "
+        "Each agent reads structured input and produces a structured payload. Schemas become contracts: a draft must cite the outline it followed, a review must list issues with severities. "
+        "Quality gates between stages block weak outputs from reaching downstream agents. The pipeline is observable because every step writes a typed artifact to disk. "
+        "When something fails, you see exactly where. The schema contracts also let you swap implementations: a flash model for cheap stages, a pro model for the ones that matter, a stub for tests. "
+        "Each stage is independently improvable; you can replace the drafting prompt without touching review. That is what makes the system feel less like a script and more like infrastructure.\n\n"
+        "## Applying it to your team\n\n"
+        "Start small. Build an intake agent that turns a free-text request into a structured brief. Add an outline agent next. "
+        "Once both work, add a quality gate between them — does the brief specify an audience? a goal? Reject runs that do not. "
+        "Layer in research, drafting, and review only once the upstream contracts hold. The pipeline grows in the order it should: contract first, agent second. "
+        "The first version of this pattern can ship in a week. The first version that catches a hallucination at the gate, before it reaches a human reviewer, will pay for itself in saved cycles within a month. "
+        "Teams that adopt this pattern stop debating prompts in Slack and start debating schemas in pull requests, which is exactly the upgrade you want.\n"
+    )
+    draft = {
+        "markdown": draft_markdown,
+        "word_count": len(draft_markdown.split()),
+        "sections_covered": [s["heading"] for s in sections],
+    }
+    review = {
+        "issues": [
+            {
+                "severity": "minor",
+                "location": "Applying it to your team",
+                "description": "Could mention specific tooling examples.",
+                "suggested_fix": "Reference Prefect, LangGraph, or similar if relevant.",
+            }
+        ],
+        "blocking_issues_count": 0,
+        "overall_assessment": "Solid first draft; one minor suggestion.",
+    }
+    edited = {
+        "markdown": draft_markdown.replace(
+            "Layer in research, drafting, and review only once the upstream contracts hold.",
+            "Layer in research, drafting, and review only once the upstream contracts hold. Frameworks like LangGraph or Prefect can manage the wiring once the shape is clear.",
+        ),
+        "word_count": len(draft_markdown.split()) + 16,
+        "changes_made": [
+            "Added a tooling pointer in the closing section in response to reviewer minor."
+        ],
+        "resolved_issues": ["Could mention specific tooling examples."],
+    }
+    repurposed = {
+        "linkedin_post": (
+            "Most teams treat LLMs as a single magic box. The teams that ship reliably "
+            "split the box into stages — intake, research, outline, draft, review, edit, "
+            "repurpose, QA — and put quality gates between them. Each agent owns one "
+            "task. Each output is a typed artifact you can inspect. The result is a "
+            "workflow you can debug instead of a black box you have to retry. Start "
+            "with a structured intake and an outline; add gates between them; layer "
+            "the rest in once the upstream contracts hold."
+        ),
+        "x_thread": [
+            "Most teams treat LLMs as a single magic box. The teams that ship reliably split the box into stages.",
+            "Intake, research, outline, draft, review, edit, repurpose, QA. Each step has its own agent and its own typed output.",
+            "Schemas become contracts. A weak intake fails the gate before it pollutes downstream stages. You see where things break.",
+            "Start tiny: intake -> outline + a gate between them. Add the rest only after the contract holds. Pipelines grow shape-first.",
+        ],
+        "youtube_description": (
+            "How a multi-agent content pipeline beats one-shot LLM calls. "
+            "Chapters: 1) The cost of one-shot LLM workflows. 2) What changes when "
+            "you split the work. 3) Applying it to your team. Built for technical "
+            "PMs and engineering leads who already use LLMs day-to-day."
+        ),
+        "short_form_script": (
+            "Stop pasting prompts and praying. Split the work. Intake. Outline. "
+            "Draft. Review. Each stage is a contract. Each output is something you "
+            "can inspect. That's the difference between demos and shipping."
+        ),
+        "newsletter_blurb": (
+            "If your LLM workflow is one big prompt, you are stuck debugging a black "
+            "box. This week: how to split the work into staged agents with contracts "
+            "between them — and the smallest version of the pattern that still pays "
+            "off. Five-minute read."
+        ),
+        "readme_excerpt": (
+            "## Background\n\nThis project ships a multi-agent content pipeline: "
+            "intake, research, outline, draft, technical review, edit, repurposing, "
+            "and publishing QA. Each stage has its own agent, its own JSON Schema, "
+            "and an optional quality gate that can reject the stage's output and "
+            "trigger a bounded revision pass."
+        ),
+    }
+    publishing_qa = {
+        "findings": [],
+        "qa_score": 92,
+        "publishable": True,
+        "blocking_issues": [],
+    }
+
+    stages = [
+        StageDefinition(
+            stage_id="intake",
+            agent=_stub_agent("intake", "Intake (stub)", brief),
+            gate=IntakeGate(),
+        ),
+        StageDefinition(
+            stage_id="research",
+            agent=_stub_agent("research", "Research (stub)", research),
+        ),
+        StageDefinition(
+            stage_id="outline",
+            agent=_stub_agent("outline", "Outline (stub)", outline),
+            gate=OutlineGate(),
+        ),
+        StageDefinition(
+            stage_id="draft",
+            agent=_stub_agent("draft", "Drafting (stub)", draft),
+            gate=DraftGate(),
+        ),
+        StageDefinition(
+            stage_id="technical_review",
+            agent=_stub_agent("technical_review", "Technical Review (stub)", review),
+            gate=TechnicalReviewGate(),
+        ),
+        StageDefinition(
+            stage_id="editor",
+            agent=_stub_agent("editor", "Editor (stub)", edited),
+        ),
+        StageDefinition(
+            stage_id="repurposing",
+            agent=_stub_agent("repurposing", "Repurposing (stub)", repurposed),
+            optional=True,
+        ),
+        StageDefinition(
+            stage_id="publishing_qa",
+            agent=_stub_agent("publishing_qa", "Publishing QA (stub)", publishing_qa),
+            gate=FinalQAGate(),
+            optional=True,
+        ),
+    ]
+    return AgentRegistry(stages)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--resume", type=str, default=None)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Use stub agents (no LLM calls). Useful for smoke verification.",
+    )
+    parser.add_argument("--auto-approve", action="store_true", default=True)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    pipeline_input = json.loads(args.input.read_text())
+    registry = _build_dry_run_registry() if args.dry_run else build_default_registry()
+    pipeline = ContentPipeline(registry=registry, output_root=args.output_root)
+    run = pipeline.run(
+        pipeline_input=pipeline_input,
+        resume_run_id=args.resume,
+        auto_approve=args.auto_approve,
+    )
+
+    print(f"\nRun id:      {run.run_id}")
+    print(f"Status:      {run.status.value}")
+    print(f"Output dir:  {args.output_root / run.run_id}")
+    if run.artifacts:
+        print("Artifacts:")
+        for name, path in sorted(run.artifacts.items()):
+            print(f"  {name}: {path}")
+    return 0 if run.status is PipelineStatus.COMPLETED else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/sample_input.json
+++ b/examples/sample_input.json
@@ -1,0 +1,5 @@
+{
+  "raw_input": "Write a technical article explaining how multi-agent orchestration can improve AI-native product development workflows, using a PRD-to-artifacts pipeline as the example. The audience is technical product managers and engineering leads who already use LLMs day-to-day but treat them as one-shot wrappers. The piece should compare the one-shot approach to a staged multi-agent pipeline (intake, research, outline, draft, review, edit, repurposing, QA), explain why each stage helps, and end with a concrete pattern they can apply to their own workflow.",
+  "audience_hint": "technical product managers and engineering leads",
+  "content_type_hint": "blog_post"
+}

--- a/pipeline/agents/__init__.py
+++ b/pipeline/agents/__init__.py
@@ -1,0 +1,96 @@
+"""Content-pipeline agents and the default registry that wires them together."""
+
+from __future__ import annotations
+
+from pipeline.agents.base import (
+    AgentMetadata,
+    AgentResult,
+    ContentAgent,
+    PipelineContext,
+)
+from pipeline.agents.drafting_agent import DraftingAgent
+from pipeline.agents.editor_agent import EditorAgent
+from pipeline.agents.intake_agent import IntakeAgent
+from pipeline.agents.outline_agent import OutlineAgent
+from pipeline.agents.publishing_qa_agent import PublishingQAAgent
+from pipeline.agents.repurposing_agent import RepurposingAgent
+from pipeline.agents.research_agent import ResearchAgent
+from pipeline.agents.technical_reviewer_agent import TechnicalReviewerAgent
+
+__all__ = [
+    "AgentMetadata",
+    "AgentResult",
+    "ContentAgent",
+    "DraftingAgent",
+    "EditorAgent",
+    "IntakeAgent",
+    "OutlineAgent",
+    "PipelineContext",
+    "PublishingQAAgent",
+    "RepurposingAgent",
+    "ResearchAgent",
+    "TechnicalReviewerAgent",
+    "build_default_registry",
+]
+
+
+def build_default_registry():
+    """Return the production :class:`AgentRegistry` with all 8 stages wired up.
+
+    Imported lazily to avoid a circular import: ``pipeline.content_pipeline.registry``
+    depends on agent and gate types defined in this package.
+    """
+    from pipeline.content_pipeline.quality_gates import (
+        DraftGate,
+        FinalQAGate,
+        IntakeGate,
+        OutlineGate,
+        TechnicalReviewGate,
+    )
+    from pipeline.content_pipeline.registry import AgentRegistry, StageDefinition
+
+    stages = [
+        StageDefinition(
+            stage_id="intake",
+            agent=IntakeAgent(),
+            gate=IntakeGate(),
+        ),
+        StageDefinition(
+            stage_id="research",
+            agent=ResearchAgent(),
+            gate=None,
+        ),
+        StageDefinition(
+            stage_id="outline",
+            agent=OutlineAgent(),
+            gate=OutlineGate(),
+        ),
+        StageDefinition(
+            stage_id="draft",
+            agent=DraftingAgent(),
+            gate=DraftGate(),
+        ),
+        StageDefinition(
+            stage_id="technical_review",
+            agent=TechnicalReviewerAgent(),
+            gate=TechnicalReviewGate(),
+        ),
+        StageDefinition(
+            stage_id="editor",
+            agent=EditorAgent(),
+            gate=None,
+        ),
+        StageDefinition(
+            stage_id="repurposing",
+            agent=RepurposingAgent(),
+            gate=None,
+            optional=True,
+        ),
+        StageDefinition(
+            stage_id="publishing_qa",
+            agent=PublishingQAAgent(),
+            gate=FinalQAGate(),
+            optional=True,
+        ),
+    ]
+    return AgentRegistry(stages)

--- a/pipeline/agents/base.py
+++ b/pipeline/agents/base.py
@@ -1,0 +1,97 @@
+"""Shared types and base class for content-pipeline agents."""
+
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pipeline.llm_client import generate_with_retry, get_provider
+from pipeline.schemas import SCHEMAS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentMetadata:
+    """Lightweight per-call telemetry returned alongside an :class:`AgentResult`."""
+
+    model: str | None = None
+    duration_ms: int = 0
+    retry_count: int = 0
+
+
+@dataclass(frozen=True)
+class AgentResult:
+    """Outcome of a single agent invocation.
+
+    Payloads are plain dicts validated by jsonschema, matching the rest of the
+    repo. A failed result still carries :attr:`metadata` when available so the
+    run record can show where time was spent.
+    """
+
+    success: bool
+    output: dict[str, Any] | None = None
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    metadata: AgentMetadata | None = None
+
+
+@dataclass
+class PipelineContext:
+    """Mutable execution context passed to every agent."""
+
+    run_id: str
+    output_dir: Path
+    input: dict[str, Any]
+    previous_outputs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    gate_feedback: list[str] = field(default_factory=list)
+
+
+class ContentAgent(ABC):
+    """Base class every content-pipeline agent inherits from.
+
+    Concrete agents declare four class-level metadata attributes — ``STAGE_ID``,
+    ``ARTIFACT_TYPE`` (the key in ``config.json``'s ``artifact_provider_map``),
+    ``SCHEMA_KEY`` (the key in ``schemas.SCHEMAS``), and ``PROMPT_FILE`` (the
+    template name under ``pipeline/prompts/content_pipeline/``) — and implement
+    :meth:`run`. The :meth:`_call_llm` helper wires the standard provider call
+    with retry and schema validation.
+    """
+
+    id: str
+    name: str
+    description: str
+
+    STAGE_ID: str
+    ARTIFACT_TYPE: str
+    SCHEMA_KEY: str
+    PROMPT_FILE: str
+
+    @abstractmethod
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:  # pragma: no cover - abstract
+        """Execute the agent and return an :class:`AgentResult`."""
+
+    def _call_llm(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> tuple[dict[str, Any], AgentMetadata]:
+        """Invoke the configured provider with retry + schema validation."""
+        provider = get_provider(self.ARTIFACT_TYPE)
+        schema = SCHEMAS[self.SCHEMA_KEY]
+        start = time.monotonic()
+        try:
+            payload = generate_with_retry(provider, system_prompt, user_prompt, schema)
+        finally:
+            duration_ms = int((time.monotonic() - start) * 1000)
+        metadata = AgentMetadata(
+            model=getattr(provider, "model", None),
+            duration_ms=duration_ms,
+        )
+        return payload, metadata

--- a/pipeline/agents/drafting_agent.py
+++ b/pipeline/agents/drafting_agent.py
@@ -1,0 +1,53 @@
+"""Drafting Agent — produces the first full draft from outline + brief + research."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class DraftingAgent(ContentAgent):
+    id = "draft"
+    name = "Drafting Agent"
+    description = "Generates the first full Markdown draft from the outline."
+
+    STAGE_ID = "draft"
+    ARTIFACT_TYPE = "agent_draft"
+    SCHEMA_KEY = "draft"
+    PROMPT_FILE = "draft"
+
+    SYSTEM_PROMPT = (
+        "You are a senior technical writer. You produce a clear first draft "
+        "that follows the supplied outline exactly, matches the audience and "
+        "depth in the brief, and avoids placeholder text. Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        brief = context.previous_outputs.get("intake")
+        outline = context.previous_outputs.get("outline")
+        research = context.previous_outputs.get("research")
+        if not (brief and outline):
+            return AgentResult(
+                success=False,
+                errors=("draft stage requires intake and outline outputs in context",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            brief_json=brief,
+            outline_json=outline,
+            research_json=research or {},
+            gate_feedback="\n".join(f"- {f}" for f in context.gate_feedback),
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/agents/editor_agent.py
+++ b/pipeline/agents/editor_agent.py
@@ -1,0 +1,56 @@
+"""Editor Agent — improves clarity and resolves reviewer feedback in the draft."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class EditorAgent(ContentAgent):
+    id = "editor"
+    name = "Editor Agent"
+    description = (
+        "Improves clarity, structure, and concision while preserving technical "
+        "meaning and resolving reviewer feedback."
+    )
+
+    STAGE_ID = "editor"
+    ARTIFACT_TYPE = "agent_editor"
+    SCHEMA_KEY = "edited_draft"
+    PROMPT_FILE = "editor"
+
+    SYSTEM_PROMPT = (
+        "You are a meticulous editor who tightens technical prose without "
+        "altering its meaning. You resolve reviewer issues and report the "
+        "edits you made. Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        draft = context.previous_outputs.get("draft") or {}
+        review = context.previous_outputs.get("technical_review") or {}
+        brief = context.previous_outputs.get("intake")
+        markdown = draft.get("markdown")
+        if not markdown:
+            return AgentResult(
+                success=False,
+                errors=("editor stage requires a draft markdown in context",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            draft_markdown=markdown,
+            review_json=review,
+            brief_json=brief or {},
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/agents/intake_agent.py
+++ b/pipeline/agents/intake_agent.py
@@ -1,0 +1,51 @@
+"""Intake Agent — parses raw user input into a normalized ContentBrief."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class IntakeAgent(ContentAgent):
+    id = "intake"
+    name = "Intake Agent"
+    description = "Parses raw input into a normalized ContentBrief."
+
+    STAGE_ID = "intake"
+    ARTIFACT_TYPE = "agent_intake"
+    SCHEMA_KEY = "content_brief"
+    PROMPT_FILE = "intake"
+
+    SYSTEM_PROMPT = (
+        "You are a senior technical-content strategist. You read raw inputs "
+        "(ideas, transcripts, notes, drafts) and extract a normalized brief. "
+        "Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        raw_input = stage_input.get("raw_input", "").strip()
+        if not raw_input:
+            return AgentResult(
+                success=False,
+                errors=("intake stage requires non-empty raw_input",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            raw_input=raw_input,
+            audience_hint=stage_input.get("audience_hint", ""),
+            content_type_hint=stage_input.get("content_type_hint", ""),
+            gate_feedback="\n".join(f"- {f}" for f in context.gate_feedback),
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/agents/outline_agent.py
+++ b/pipeline/agents/outline_agent.py
@@ -1,0 +1,56 @@
+"""Outline Agent — turns the brief and research notes into a structured outline."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class OutlineAgent(ContentAgent):
+    id = "outline"
+    name = "Outline Agent"
+    description = "Converts a brief and research notes into a structured outline."
+
+    STAGE_ID = "outline"
+    ARTIFACT_TYPE = "agent_outline"
+    SCHEMA_KEY = "content_outline"
+    PROMPT_FILE = "outline"
+
+    SYSTEM_PROMPT = (
+        "You are an experienced editor who builds outlines for technical content. "
+        "You produce ordered, audience-appropriate outlines with explicit section "
+        "purposes and key points. Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        brief = context.previous_outputs.get("intake")
+        research = context.previous_outputs.get("research")
+        if not brief:
+            return AgentResult(
+                success=False,
+                errors=("outline stage requires an intake output in context",),
+            )
+        if not research:
+            return AgentResult(
+                success=False,
+                errors=("outline stage requires a research output in context",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            brief_json=brief,
+            research_json=research,
+            gate_feedback="\n".join(f"- {f}" for f in context.gate_feedback),
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/agents/publishing_qa_agent.py
+++ b/pipeline/agents/publishing_qa_agent.py
@@ -1,0 +1,58 @@
+"""Publishing QA Agent — final quality gate before content is shipped."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class PublishingQAAgent(ContentAgent):
+    id = "publishing_qa"
+    name = "Publishing QA Agent"
+    description = (
+        "Reviews the edited long-form draft and the repurposed assets together "
+        "and reports whether the package is publishable."
+    )
+
+    STAGE_ID = "publishing_qa"
+    ARTIFACT_TYPE = "agent_publishing_qa"
+    SCHEMA_KEY = "publishing_qa"
+    PROMPT_FILE = "publishing_qa"
+
+    SYSTEM_PROMPT = (
+        "You are the final quality gate before publishing. You produce a "
+        "structured findings list with severities, a 0-100 QA score, and a "
+        "publishable boolean. Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        edited = context.previous_outputs.get("editor") or {}
+        repurposed = context.previous_outputs.get("repurposing") or {}
+        outline = context.previous_outputs.get("outline")
+        brief = context.previous_outputs.get("intake")
+        markdown = edited.get("markdown")
+        if not markdown:
+            return AgentResult(
+                success=False,
+                errors=("publishing_qa stage requires edited draft markdown in context",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            edited_markdown=markdown,
+            repurposed_json=repurposed,
+            brief_json=brief or {},
+            outline_json=outline or {},
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/agents/repurposing_agent.py
+++ b/pipeline/agents/repurposing_agent.py
@@ -1,0 +1,56 @@
+"""Repurposing Agent — derives channel-specific assets from the edited draft."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class RepurposingAgent(ContentAgent):
+    id = "repurposing"
+    name = "Repurposing Agent"
+    description = (
+        "Converts the edited long-form draft into LinkedIn, X thread, YouTube, "
+        "short-form, newsletter, and README assets."
+    )
+
+    STAGE_ID = "repurposing"
+    ARTIFACT_TYPE = "agent_repurposing"
+    SCHEMA_KEY = "repurposed_assets"
+    PROMPT_FILE = "repurposing"
+
+    SYSTEM_PROMPT = (
+        "You are a multi-channel content adapter. You produce asset variants "
+        "that match each channel's voice and length conventions while "
+        "preserving the source's technical accuracy. Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        edited = context.previous_outputs.get("editor") or {}
+        outline = context.previous_outputs.get("outline")
+        brief = context.previous_outputs.get("intake")
+        markdown = edited.get("markdown")
+        if not markdown:
+            return AgentResult(
+                success=False,
+                errors=("repurposing stage requires edited draft markdown in context",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            edited_markdown=markdown,
+            brief_json=brief or {},
+            outline_json=outline or {},
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/agents/research_agent.py
+++ b/pipeline/agents/research_agent.py
@@ -1,0 +1,52 @@
+"""Research Agent — surfaces claims, assumptions, and open questions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class ResearchAgent(ContentAgent):
+    id = "research"
+    name = "Research Agent"
+    description = (
+        "Extracts research questions, supporting points, assumptions, and open "
+        "questions. Marks claims that need external verification."
+    )
+
+    STAGE_ID = "research"
+    ARTIFACT_TYPE = "agent_research"
+    SCHEMA_KEY = "research_notes"
+    PROMPT_FILE = "research"
+
+    SYSTEM_PROMPT = (
+        "You are a careful technical researcher. You list the claims a piece "
+        "would need to support, mark which ones require external verification, "
+        "and surface assumptions the draft will rest on. Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        brief = context.previous_outputs.get("intake")
+        if not brief:
+            return AgentResult(
+                success=False,
+                errors=("research stage requires an intake output in context",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            brief_json=brief,
+            gate_feedback="\n".join(f"- {f}" for f in context.gate_feedback),
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/agents/technical_reviewer_agent.py
+++ b/pipeline/agents/technical_reviewer_agent.py
@@ -1,0 +1,56 @@
+"""Technical Reviewer Agent — produces a structured review report on the draft."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pipeline.agents.base import AgentResult, ContentAgent, PipelineContext
+from pipeline.content_pipeline.prompts import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class TechnicalReviewerAgent(ContentAgent):
+    id = "technical_review"
+    name = "Technical Reviewer Agent"
+    description = (
+        "Reviews the draft for technical accuracy, missing steps, vague claims, "
+        "and unsupported assumptions."
+    )
+
+    STAGE_ID = "technical_review"
+    ARTIFACT_TYPE = "agent_technical_review"
+    SCHEMA_KEY = "review_report"
+    PROMPT_FILE = "technical_review"
+
+    SYSTEM_PROMPT = (
+        "You are a careful senior engineer reviewing a technical draft. You "
+        "find problems and label their severity precisely. You do not rewrite "
+        "the prose. Respond with valid JSON only."
+    )
+
+    def run(
+        self, stage_input: dict[str, Any], context: PipelineContext
+    ) -> AgentResult:
+        draft = context.previous_outputs.get("draft") or {}
+        brief = context.previous_outputs.get("intake")
+        research = context.previous_outputs.get("research") or {}
+        markdown = draft.get("markdown")
+        if not markdown:
+            return AgentResult(
+                success=False,
+                errors=("technical_review stage requires a draft markdown in context",),
+            )
+        user_prompt = render_prompt(
+            self.PROMPT_FILE,
+            draft_markdown=markdown,
+            brief_json=brief or {},
+            research_json=research,
+        )
+        try:
+            payload, metadata = self._call_llm(self.SYSTEM_PROMPT, user_prompt)
+        except RuntimeError as exc:
+            logger.warning("[run=%s stage=%s] LLM call failed: %s", context.run_id, self.STAGE_ID, exc)
+            return AgentResult(success=False, errors=(str(exc),))
+        return AgentResult(success=True, output=payload, metadata=metadata)

--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -61,6 +61,14 @@
     "adapt_code": "gemini",
     "judge": "gemini",
     "knowledge_graph": "gemini_flash",
-    "playground_config": "gemini_flash"
+    "playground_config": "gemini_flash",
+    "agent_intake": "gemini_flash",
+    "agent_research": "gemini_flash",
+    "agent_outline": "gemini_flash",
+    "agent_draft": "gemini",
+    "agent_technical_review": "gemini",
+    "agent_editor": "gemini",
+    "agent_repurposing": "gemini_flash",
+    "agent_publishing_qa": "gemini_flash"
   }
 }

--- a/pipeline/content_pipeline/__init__.py
+++ b/pipeline/content_pipeline/__init__.py
@@ -1,0 +1,32 @@
+"""Multi-agent content orchestration pipeline.
+
+This package composes specialized agents (intake, research, outline, draft,
+technical review, edit, repurposing, publishing QA) into an explicit pipeline
+with quality gates between stages, structured run state, and on-disk artifacts.
+
+It is independent of `pipeline.generate`, which orchestrates per-technique
+artifact generation for the optimization-algorithm site. Both share the same
+LLM client, schemas, and prompt-template idioms.
+"""
+
+from pipeline.content_pipeline.pipeline import ContentPipeline
+from pipeline.content_pipeline.quality_gates import QualityGateResult
+from pipeline.content_pipeline.state import (
+    ContentPipelineRun,
+    PipelineStatus,
+    StageRun,
+    StageStatus,
+    load_run,
+    save_run,
+)
+
+__all__ = [
+    "ContentPipeline",
+    "ContentPipelineRun",
+    "PipelineStatus",
+    "QualityGateResult",
+    "StageRun",
+    "StageStatus",
+    "load_run",
+    "save_run",
+]

--- a/pipeline/content_pipeline/history.py
+++ b/pipeline/content_pipeline/history.py
@@ -1,0 +1,30 @@
+"""Helpers for browsing prior pipeline runs on disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pipeline.content_pipeline.state import (
+    ContentPipelineRun,
+    RUN_FILENAME,
+    load_run,
+)
+
+
+def list_runs(root: Path) -> list[str]:
+    """Return the run ids under ``root`` that have a ``run.json``, newest first."""
+    if not root.exists():
+        return []
+    candidates = []
+    for child in root.iterdir():
+        if child.is_dir() and (child / RUN_FILENAME).exists():
+            candidates.append(child.name)
+    return sorted(candidates, reverse=True)
+
+
+def load_latest(root: Path) -> ContentPipelineRun | None:
+    """Return the most recent run under ``root``, or ``None`` if none exist."""
+    ids = list_runs(root)
+    if not ids:
+        return None
+    return load_run(ids[0], root)

--- a/pipeline/content_pipeline/pipeline.py
+++ b/pipeline/content_pipeline/pipeline.py
@@ -1,0 +1,331 @@
+"""ContentPipeline — sequential orchestrator for the multi-agent content flow."""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pipeline.agents.base import PipelineContext
+from pipeline.content_pipeline.registry import AgentRegistry, StageDefinition
+from pipeline.content_pipeline.state import (
+    ContentPipelineRun,
+    PipelineStatus,
+    StageRun,
+    StageStatus,
+    load_run,
+    save_run,
+    utc_now_iso,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_ROOT = Path("outputs/runs")
+
+
+class PipelineFailure(RuntimeError):
+    """Raised when the pipeline cannot make progress and must stop."""
+
+
+class ContentPipeline:
+    """Compose the registered agents into a sequential, gated pipeline.
+
+    Usage::
+
+        pipeline = ContentPipeline(build_default_registry())
+        run = pipeline.run({"raw_input": "..."})
+    """
+
+    def __init__(
+        self,
+        registry: AgentRegistry,
+        output_root: Path | str = DEFAULT_OUTPUT_ROOT,
+    ):
+        self.registry = registry
+        self.output_root = Path(output_root)
+
+    # ------------------------------------------------------------------ run
+
+    def run(
+        self,
+        pipeline_input: dict[str, Any],
+        resume_run_id: str | None = None,
+        auto_approve: bool = True,
+    ) -> ContentPipelineRun:
+        """Execute the pipeline end-to-end (or resume an interrupted run)."""
+        if resume_run_id:
+            run = load_run(resume_run_id, self.output_root)
+            run.status = PipelineStatus.RUNNING
+            logger.info("[run=%s] resuming pipeline", run.run_id)
+        else:
+            run = self._init_run(pipeline_input)
+            logger.info("[run=%s] starting pipeline", run.run_id)
+
+        run_dir = self.output_root / run.run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        context = PipelineContext(
+            run_id=run.run_id,
+            output_dir=run_dir,
+            input=run.input,
+            previous_outputs=self._load_previous_outputs(run, run_dir),
+            gate_feedback=[],
+        )
+
+        save_run(run, run_dir)
+
+        try:
+            for stage_def in self.registry.iter_stages():
+                stage_run = self._ensure_stage(run, stage_def)
+
+                if (
+                    stage_run.status is StageStatus.SUCCEEDED
+                    and stage_run.output_path
+                    and Path(stage_run.output_path).exists()
+                ):
+                    logger.info(
+                        "[run=%s stage=%s] already succeeded; skipping",
+                        run.run_id,
+                        stage_def.stage_id,
+                    )
+                    context.previous_outputs[stage_def.stage_id] = json.loads(
+                        Path(stage_run.output_path).read_text()
+                    )
+                    continue
+
+                self._run_stage(run, stage_def, stage_run, context, run_dir)
+
+                if (
+                    stage_def.stage_id == "technical_review"
+                    and not auto_approve
+                    and (context.previous_outputs.get("technical_review", {})
+                         .get("requires_human"))
+                ):
+                    run.status = PipelineStatus.WAITING_FOR_REVIEW
+                    save_run(run, run_dir)
+                    logger.info(
+                        "[run=%s] paused for human review after technical_review",
+                        run.run_id,
+                    )
+                    return run
+
+            self._finalize_artifacts(run, run_dir)
+            run.status = PipelineStatus.COMPLETED
+            run.finished_at = utc_now_iso()
+            save_run(run, run_dir)
+            logger.info("[run=%s] pipeline completed", run.run_id)
+            return run
+
+        except PipelineFailure as exc:
+            run.status = PipelineStatus.FAILED
+            run.finished_at = utc_now_iso()
+            save_run(run, run_dir)
+            logger.warning("[run=%s] pipeline failed: %s", run.run_id, exc)
+            return run
+
+    # -------------------------------------------------------------- helpers
+
+    def cancel(self, run_id: str) -> None:
+        """Reserved for future use — cancellation requires an external signal."""
+        raise NotImplementedError(
+            "Pipeline cancellation is not yet implemented; the status is reserved."
+        )
+
+    def _init_run(self, pipeline_input: dict[str, Any]) -> ContentPipelineRun:
+        now = datetime.now(timezone.utc)
+        run_id = (
+            now.strftime("%Y%m%dT%H%M%SZ")
+            + "-"
+            + secrets.token_hex(3)
+        )
+        stages = [
+            StageRun(stage_id=s.stage_id, name=s.agent.name)
+            for s in self.registry.iter_stages()
+        ]
+        return ContentPipelineRun(
+            run_id=run_id,
+            status=PipelineStatus.RUNNING,
+            input=pipeline_input,
+            stages=stages,
+            started_at=now.isoformat(),
+        )
+
+    def _ensure_stage(
+        self,
+        run: ContentPipelineRun,
+        stage_def: StageDefinition,
+    ) -> StageRun:
+        stage_run = run.stage(stage_def.stage_id)
+        if stage_run is None:
+            stage_run = StageRun(stage_id=stage_def.stage_id, name=stage_def.agent.name)
+            run.stages.append(stage_run)
+        return stage_run
+
+    def _load_previous_outputs(
+        self,
+        run: ContentPipelineRun,
+        run_dir: Path,
+    ) -> dict[str, dict[str, Any]]:
+        previous: dict[str, dict[str, Any]] = {}
+        for stage in run.stages:
+            if stage.status is StageStatus.SUCCEEDED and stage.output_path:
+                path = Path(stage.output_path)
+                if path.exists():
+                    previous[stage.stage_id] = json.loads(path.read_text())
+        return previous
+
+    def _run_stage(
+        self,
+        run: ContentPipelineRun,
+        stage_def: StageDefinition,
+        stage_run: StageRun,
+        context: PipelineContext,
+        run_dir: Path,
+    ) -> None:
+        attempts_remaining = stage_def.max_revisions + 1
+        while attempts_remaining > 0:
+            attempts_remaining -= 1
+            stage_run.status = StageStatus.RUNNING
+            stage_run.started_at = utc_now_iso()
+            stage_run.error = None
+            save_run(run, run_dir)
+            logger.info(
+                "[run=%s stage=%s] starting (gate_feedback=%d)",
+                run.run_id,
+                stage_def.stage_id,
+                len(context.gate_feedback),
+            )
+
+            stage_input = context.input if stage_def.stage_id == "intake" else {}
+            result = stage_def.agent.run(stage_input, context)
+            stage_run.finished_at = utc_now_iso()
+            if result.metadata is not None:
+                stage_run.metadata = asdict(result.metadata)
+
+            if not result.success or result.output is None:
+                error_msg = "; ".join(result.errors) or "agent reported failure"
+                stage_run.error = error_msg
+                if stage_def.optional:
+                    stage_run.status = StageStatus.SKIPPED
+                    logger.warning(
+                        "[run=%s stage=%s] optional stage skipped: %s",
+                        run.run_id,
+                        stage_def.stage_id,
+                        error_msg,
+                    )
+                    save_run(run, run_dir)
+                    return
+                stage_run.status = StageStatus.FAILED
+                save_run(run, run_dir)
+                raise PipelineFailure(
+                    f"stage {stage_def.stage_id} failed: {error_msg}"
+                )
+
+            output_path = run_dir / f"{stage_def.stage_id}.json"
+            output_path.write_text(json.dumps(result.output, indent=2))
+            stage_run.output_path = str(output_path)
+            context.previous_outputs[stage_def.stage_id] = result.output
+
+            if stage_def.gate is not None:
+                gate_result = stage_def.gate.evaluate(
+                    result.output, context.previous_outputs
+                )
+                run.gate_results.append(asdict(gate_result))
+                save_run(run, run_dir)
+                if not gate_result.passed:
+                    if attempts_remaining > 0:
+                        stage_run.status = StageStatus.NEEDS_REVISION
+                        stage_run.retries += 1
+                        context.gate_feedback = list(gate_result.failures)
+                        logger.warning(
+                            "[run=%s stage=%s] gate %s failed: %s — revising",
+                            run.run_id,
+                            stage_def.stage_id,
+                            gate_result.gate_id,
+                            list(gate_result.failures),
+                        )
+                        save_run(run, run_dir)
+                        continue
+                    if stage_def.optional:
+                        stage_run.status = StageStatus.SKIPPED
+                        stage_run.error = (
+                            f"gate {gate_result.gate_id} failed: "
+                            f"{list(gate_result.failures)}"
+                        )
+                        logger.warning(
+                            "[run=%s stage=%s] optional stage skipped after gate exhaustion",
+                            run.run_id,
+                            stage_def.stage_id,
+                        )
+                        save_run(run, run_dir)
+                        return
+                    stage_run.status = StageStatus.FAILED
+                    stage_run.error = (
+                        f"gate {gate_result.gate_id} failed after retries: "
+                        f"{list(gate_result.failures)}"
+                    )
+                    save_run(run, run_dir)
+                    raise PipelineFailure(stage_run.error)
+
+            stage_run.status = StageStatus.SUCCEEDED
+            context.gate_feedback = []
+            save_run(run, run_dir)
+            logger.info(
+                "[run=%s stage=%s] succeeded (retries=%d)",
+                run.run_id,
+                stage_def.stage_id,
+                stage_run.retries,
+            )
+            return
+
+    def _finalize_artifacts(self, run: ContentPipelineRun, run_dir: Path) -> None:
+        """Write derived markdown files alongside the JSON stage outputs."""
+        artifacts: dict[str, str] = {}
+        for stage in run.stages:
+            if stage.output_path:
+                artifacts[f"{stage.stage_id}.json"] = stage.output_path
+
+        previous_outputs: dict[str, dict[str, Any]] = {}
+        for stage in run.stages:
+            if stage.status is StageStatus.SUCCEEDED and stage.output_path:
+                previous_outputs[stage.stage_id] = json.loads(
+                    Path(stage.output_path).read_text()
+                )
+
+        draft = previous_outputs.get("draft") or {}
+        if draft.get("markdown"):
+            path = run_dir / "draft.md"
+            path.write_text(draft["markdown"])
+            artifacts["draft.md"] = str(path)
+
+        edited = previous_outputs.get("editor") or {}
+        if edited.get("markdown"):
+            path = run_dir / "edited-draft.md"
+            path.write_text(edited["markdown"])
+            artifacts["edited-draft.md"] = str(path)
+
+        repurposed = previous_outputs.get("repurposing") or {}
+        if repurposed:
+            mapping = {
+                "linkedin-post.md": repurposed.get("linkedin_post"),
+                "x-thread.md": (
+                    "\n\n".join(repurposed.get("x_thread") or [])
+                    if repurposed.get("x_thread")
+                    else None
+                ),
+                "youtube-description.md": repurposed.get("youtube_description"),
+                "short-form-script.md": repurposed.get("short_form_script"),
+                "newsletter-blurb.md": repurposed.get("newsletter_blurb"),
+                "readme-excerpt.md": repurposed.get("readme_excerpt"),
+            }
+            for filename, content in mapping.items():
+                if content:
+                    path = run_dir / filename
+                    path.write_text(content)
+                    artifacts[filename] = str(path)
+
+        run.artifacts = artifacts

--- a/pipeline/content_pipeline/prompts.py
+++ b/pipeline/content_pipeline/prompts.py
@@ -1,0 +1,41 @@
+"""Prompt-template helper for the multi-agent content pipeline.
+
+Mirrors the ``{{var}}`` substitution style used by ``pipeline.generator``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pipeline.paths import PROMPTS_DIR
+
+CONTENT_PROMPTS_DIR = PROMPTS_DIR / "content_pipeline"
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    return json.dumps(value, indent=2, sort_keys=False, ensure_ascii=False)
+
+
+def render_prompt(template_name: str, **variables: Any) -> str:
+    """Load ``content_pipeline/<template_name>.md`` and substitute ``{{var}}`` placeholders.
+
+    Missing variables resolve to an empty string so optional placeholders
+    (e.g. ``gate_feedback`` on the first attempt) do not require callers to
+    pass them explicitly.
+    """
+    template_path = CONTENT_PROMPTS_DIR / f"{template_name}.md"
+    template = template_path.read_text()
+    rendered = template
+    for key, value in variables.items():
+        rendered = rendered.replace(f"{{{{{key}}}}}", _stringify(value))
+    # Wipe any unfilled placeholders rather than leaking literal ``{{x}}`` to the model.
+    while "{{" in rendered and "}}" in rendered:
+        start = rendered.index("{{")
+        end = rendered.index("}}", start) + 2
+        rendered = rendered[:start] + rendered[end:]
+    return rendered

--- a/pipeline/content_pipeline/quality_gates.py
+++ b/pipeline/content_pipeline/quality_gates.py
@@ -1,0 +1,224 @@
+"""Quality gates evaluated between pipeline stages.
+
+A gate inspects the dict payload a stage produced (and optionally the
+previous-outputs context) and returns a :class:`QualityGateResult`. The
+orchestrator uses ``passed`` to decide whether to advance, retry the stage with
+the gate's failures fed back as feedback, or fail the pipeline.
+"""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+PLACEHOLDER_PATTERNS = (
+    re.compile(r"\bTODO\b"),
+    re.compile(r"\bTBD\b"),
+    re.compile(r"\[(insert|placeholder|example needed|fill in)[^\]]*\]", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class QualityGateResult:
+    """Outcome of a single gate evaluation."""
+
+    gate_id: str
+    stage_id: str
+    passed: bool
+    failures: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+class QualityGate(ABC):
+    """Abstract base class for content-pipeline quality gates."""
+
+    id: str
+    description: str
+    stage_id: str
+
+    def evaluate(
+        self,
+        payload: dict[str, Any],
+        previous_outputs: dict[str, dict[str, Any]] | None = None,
+    ) -> QualityGateResult:
+        """Run the gate and produce a structured result.
+
+        ``previous_outputs`` is the orchestrator's view of every prior stage
+        output keyed by stage id. Most gates ignore it; gates that need
+        cross-stage context (e.g. :class:`DraftGate` checking outline coverage)
+        read from it.
+        """
+        failures, warnings = self._check(payload, previous_outputs or {})
+        return QualityGateResult(
+            gate_id=self.id,
+            stage_id=self.stage_id,
+            passed=not failures,
+            failures=tuple(failures),
+            warnings=tuple(warnings),
+        )
+
+    @abstractmethod
+    def _check(
+        self,
+        payload: dict[str, Any],
+        previous_outputs: dict[str, dict[str, Any]],
+    ) -> tuple[list[str], list[str]]:  # pragma: no cover - abstract
+        """Return ``(failures, warnings)``."""
+
+
+class IntakeGate(QualityGate):
+    id = "intake_gate"
+    description = "ContentBrief must name an audience, content_type, and goals."
+    stage_id = "intake"
+
+    def _check(
+        self,
+        payload: dict[str, Any],
+        previous_outputs: dict[str, dict[str, Any]],
+    ) -> tuple[list[str], list[str]]:
+        failures: list[str] = []
+        warnings: list[str] = []
+        if not (payload.get("audience") or "").strip():
+            failures.append("Brief is missing audience")
+        if not (payload.get("content_type") or "").strip():
+            failures.append("Brief is missing content_type")
+        goals = payload.get("goals") or []
+        if not goals:
+            failures.append("Brief has no goals")
+        if not (payload.get("topic") or "").strip():
+            failures.append("Brief is missing topic")
+        return failures, warnings
+
+
+class OutlineGate(QualityGate):
+    id = "outline_gate"
+    description = (
+        "Outline must have a title, a hook, at least three sections, "
+        "and at least one technical-explanation section."
+    )
+    stage_id = "outline"
+
+    def _check(
+        self,
+        payload: dict[str, Any],
+        previous_outputs: dict[str, dict[str, Any]],
+    ) -> tuple[list[str], list[str]]:
+        failures: list[str] = []
+        warnings: list[str] = []
+        if not (payload.get("title") or "").strip():
+            failures.append("Outline is missing a title")
+        if not (payload.get("hook") or "").strip():
+            failures.append("Outline is missing a hook")
+        sections = payload.get("sections") or []
+        if len(sections) < 3:
+            failures.append(f"Outline has only {len(sections)} sections (minimum 3)")
+        types = {s.get("section_type") for s in sections}
+        if not (types & {"explanation", "deep_dive"}):
+            failures.append("Outline has no technical explanation/deep_dive section")
+        if sections and sections[0].get("section_type") != "intro":
+            warnings.append("First section is not 'intro'")
+        return failures, warnings
+
+
+class DraftGate(QualityGate):
+    id = "draft_gate"
+    description = (
+        "Draft must meet a minimum length, cover most outline sections, "
+        "and contain no placeholder markers."
+    )
+    stage_id = "draft"
+
+    MIN_WORDS = 300
+    COVERAGE_RATIO = 0.8
+
+    def _check(
+        self,
+        payload: dict[str, Any],
+        previous_outputs: dict[str, dict[str, Any]],
+    ) -> tuple[list[str], list[str]]:
+        failures: list[str] = []
+        warnings: list[str] = []
+        word_count = int(payload.get("word_count") or 0)
+        if word_count < self.MIN_WORDS:
+            failures.append(
+                f"Draft is too short ({word_count} words, minimum {self.MIN_WORDS})"
+            )
+        markdown = payload.get("markdown") or ""
+        for pattern in PLACEHOLDER_PATTERNS:
+            if pattern.search(markdown):
+                failures.append(
+                    f"Draft contains placeholder text matching /{pattern.pattern}/"
+                )
+                break
+        sections_covered = {s.lower() for s in (payload.get("sections_covered") or [])}
+        outline = previous_outputs.get("outline") or {}
+        outline_sections = {
+            (s.get("heading") or "").lower()
+            for s in (outline.get("sections") or [])
+            if s.get("heading")
+        }
+        if outline_sections:
+            covered = sections_covered & outline_sections
+            ratio = len(covered) / len(outline_sections)
+            if ratio < self.COVERAGE_RATIO:
+                missing = sorted(outline_sections - covered)
+                failures.append(
+                    "Draft covers only "
+                    f"{int(ratio * 100)}% of outline sections; "
+                    f"missing: {missing}"
+                )
+        return failures, warnings
+
+
+class TechnicalReviewGate(QualityGate):
+    id = "tech_review_gate"
+    description = "No critical-severity issues unresolved."
+    stage_id = "technical_review"
+
+    def _check(
+        self,
+        payload: dict[str, Any],
+        previous_outputs: dict[str, dict[str, Any]],
+    ) -> tuple[list[str], list[str]]:
+        failures: list[str] = []
+        warnings: list[str] = []
+        blocking = int(payload.get("blocking_issues_count") or 0)
+        critical_issues = [
+            issue
+            for issue in (payload.get("issues") or [])
+            if issue.get("severity") == "critical"
+        ]
+        if critical_issues or blocking > 0:
+            failures.append(
+                f"{max(blocking, len(critical_issues))} critical technical issue(s) reported"
+            )
+        major = [i for i in (payload.get("issues") or []) if i.get("severity") == "major"]
+        if len(major) > 5:
+            warnings.append(f"{len(major)} major issues — consider another revision pass")
+        return failures, warnings
+
+
+class FinalQAGate(QualityGate):
+    id = "final_qa_gate"
+    description = "Publishing QA must mark the package publishable."
+    stage_id = "publishing_qa"
+
+    def _check(
+        self,
+        payload: dict[str, Any],
+        previous_outputs: dict[str, dict[str, Any]],
+    ) -> tuple[list[str], list[str]]:
+        failures: list[str] = []
+        warnings: list[str] = []
+        if not payload.get("publishable", False):
+            blockers = payload.get("blocking_issues") or []
+            if blockers:
+                failures.append(f"Publishing QA blocked: {'; '.join(blockers)}")
+            else:
+                failures.append("Publishing QA marked content not publishable")
+        score = payload.get("qa_score")
+        if isinstance(score, int) and score < 60:
+            failures.append(f"QA score {score} below threshold 60")
+        return failures, warnings

--- a/pipeline/content_pipeline/registry.py
+++ b/pipeline/content_pipeline/registry.py
@@ -1,0 +1,49 @@
+"""Stage registry for the content pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator
+
+from pipeline.agents.base import ContentAgent
+from pipeline.content_pipeline.quality_gates import QualityGate
+
+
+@dataclass(frozen=True)
+class StageDefinition:
+    """One stage in the pipeline.
+
+    ``optional`` stages may fail without failing the whole pipeline (the stage
+    is recorded as ``skipped`` instead). ``max_revisions`` bounds the number of
+    gate-driven retries before a stage is marked failed.
+    """
+
+    stage_id: str
+    agent: ContentAgent
+    gate: QualityGate | None = None
+    optional: bool = False
+    max_revisions: int = 1
+
+
+class AgentRegistry:
+    """Ordered collection of stage definitions consumed by :class:`ContentPipeline`."""
+
+    def __init__(self, stages: list[StageDefinition]):
+        seen: set[str] = set()
+        for stage in stages:
+            if stage.stage_id in seen:
+                raise ValueError(f"Duplicate stage_id in registry: {stage.stage_id}")
+            seen.add(stage.stage_id)
+        self._stages = list(stages)
+
+    def get(self, stage_id: str) -> StageDefinition:
+        for stage in self._stages:
+            if stage.stage_id == stage_id:
+                return stage
+        raise KeyError(stage_id)
+
+    def iter_stages(self) -> Iterator[StageDefinition]:
+        return iter(self._stages)
+
+    def __len__(self) -> int:
+        return len(self._stages)

--- a/pipeline/content_pipeline/state.py
+++ b/pipeline/content_pipeline/state.py
@@ -1,0 +1,134 @@
+"""Pipeline and stage state types, plus on-disk persistence."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field, fields, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+RUN_FILENAME = "run.json"
+
+
+class StageStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    NEEDS_REVISION = "needs_revision"
+
+
+class PipelineStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    WAITING_FOR_REVIEW = "waiting_for_review"
+    FAILED = "failed"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class StageRun:
+    """Mutable record of one stage's execution."""
+
+    stage_id: str
+    name: str
+    status: StageStatus = StageStatus.PENDING
+    started_at: str | None = None
+    finished_at: str | None = None
+    retries: int = 0
+    error: str | None = None
+    output_path: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ContentPipelineRun:
+    """Mutable top-level run record persisted to ``outputs/runs/<run_id>/run.json``."""
+
+    run_id: str
+    status: PipelineStatus
+    input: dict[str, Any]
+    stages: list[StageRun] = field(default_factory=list)
+    gate_results: list[dict[str, Any]] = field(default_factory=list)
+    artifacts: dict[str, str] = field(default_factory=dict)
+    started_at: str = field(default_factory=utc_now_iso)
+    finished_at: str | None = None
+
+    def stage(self, stage_id: str) -> StageRun | None:
+        for stage in self.stages:
+            if stage.stage_id == stage_id:
+                return stage
+        return None
+
+
+def _to_jsonable(obj: Any) -> Any:
+    """Recursively convert dataclasses, enums, datetimes, and Paths to JSON-safe types."""
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, Path):
+        return str(obj)
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return {f.name: _to_jsonable(getattr(obj, f.name)) for f in fields(obj)}
+    if isinstance(obj, dict):
+        return {str(k): _to_jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_to_jsonable(v) for v in obj]
+    return obj
+
+
+def save_run(run: ContentPipelineRun, output_dir: Path) -> Path:
+    """Atomically persist a run to ``<output_dir>/run.json``."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_path = output_dir / RUN_FILENAME
+    tmp_path = final_path.with_suffix(".json.tmp")
+    payload = _to_jsonable(run)
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=False))
+    os.replace(tmp_path, final_path)
+    return final_path
+
+
+def load_run(run_id: str, root: Path) -> ContentPipelineRun:
+    """Load a previously persisted run from ``<root>/<run_id>/run.json``."""
+    run_path = root / run_id / RUN_FILENAME
+    if not run_path.exists():
+        raise FileNotFoundError(f"No run.json at {run_path}")
+    raw = json.loads(run_path.read_text())
+    stages = [
+        StageRun(
+            stage_id=s["stage_id"],
+            name=s["name"],
+            status=StageStatus(s["status"]),
+            started_at=s.get("started_at"),
+            finished_at=s.get("finished_at"),
+            retries=s.get("retries", 0),
+            error=s.get("error"),
+            output_path=s.get("output_path"),
+            metadata=s.get("metadata", {}) or {},
+        )
+        for s in raw.get("stages", [])
+    ]
+    return ContentPipelineRun(
+        run_id=raw["run_id"],
+        status=PipelineStatus(raw["status"]),
+        input=raw.get("input", {}),
+        stages=stages,
+        gate_results=raw.get("gate_results", []),
+        artifacts=raw.get("artifacts", {}),
+        started_at=raw.get("started_at", utc_now_iso()),
+        finished_at=raw.get("finished_at"),
+    )

--- a/pipeline/prompts/content_pipeline/draft.md
+++ b/pipeline/prompts/content_pipeline/draft.md
@@ -1,0 +1,41 @@
+You are the Drafting Agent in a multi-agent technical content pipeline. Your job is to produce the first full draft of the piece, using the outline as the source of truth.
+
+Rules:
+
+- Cover every section from the outline, in order. Use the section `heading` as a Markdown `## ` heading.
+- Honor the section's `purpose` and `key_points`. Do not invent new sections or skip existing ones.
+- Match the audience and technical_depth from the brief. Do not over-explain to advanced readers; do not under-explain to beginners.
+- Use plain, specific language. Replace abstractions with concrete examples where the outline provides material.
+- Use Markdown: `## ` for sections, fenced code blocks for code, `**bold**` and `*italic*` sparingly. Use LaTeX `$...$` only if the outline calls for math.
+- No placeholders (`TODO`, `TBD`, `[insert ...]`, `[example needed]`). If the outline does not give you the material for a point, write what you can defend from the brief and research.
+- Word count target: the outline's `estimated_word_count` ± 25%.
+
+Return:
+
+- **markdown**: the full draft as a single Markdown string.
+- **word_count**: integer, count of whitespace-separated tokens in `markdown`.
+- **sections_covered**: a list of every section heading you produced, in order.
+
+## ContentBrief
+
+```json
+{{brief_json}}
+```
+
+## ContentOutline
+
+```json
+{{outline_json}}
+```
+
+## ResearchNotes (for facts and claims)
+
+```json
+{{research_json}}
+```
+
+## Reviewer feedback from prior attempt (may be empty)
+
+{{gate_feedback}}
+
+Respond with valid JSON only, matching the Draft schema. Do not include prose outside the JSON.

--- a/pipeline/prompts/content_pipeline/editor.md
+++ b/pipeline/prompts/content_pipeline/editor.md
@@ -1,0 +1,37 @@
+You are the Editor Agent in a multi-agent technical content pipeline. Your job is to improve clarity, structure, transitions, concision, and tone, while preserving every load-bearing technical claim from the draft.
+
+Rules:
+
+- Resolve as many `critical` and `major` issues from the review report as possible. Do not silently drop content to dodge an issue.
+- Do not introduce new claims the draft did not make. If a reviewer issue cannot be resolved without new information, leave a single short note in `changes_made` saying so and leave the prose accurate but unchanged on that point.
+- Tighten wordiness. Cut hedging, prefer active voice, prefer specific nouns, prefer concrete examples.
+- Preserve outline section headings. You may merge or split paragraphs within a section.
+- Keep code blocks intact. You may correct obvious typos in identifiers but do not change algorithm semantics.
+- Word count: stay within ±15% of the input draft's word count unless the review explicitly demanded expansion or contraction.
+
+Return:
+
+- **markdown**: the edited draft as a single Markdown string.
+- **word_count**: integer, count of whitespace-separated tokens.
+- **changes_made**: a list of 3–10 concrete edits you made (e.g., "Tightened intro from 5 sentences to 3", "Replaced vague 'much faster' with the actual ratio from the source").
+- **resolved_issues**: a list of review-issue descriptions you addressed (use the issue's `description` text or `location`).
+
+## Draft (Markdown)
+
+```
+{{draft_markdown}}
+```
+
+## ReviewReport
+
+```json
+{{review_json}}
+```
+
+## ContentBrief
+
+```json
+{{brief_json}}
+```
+
+Respond with valid JSON only, matching the EditedDraft schema. Do not include prose outside the JSON.

--- a/pipeline/prompts/content_pipeline/intake.md
+++ b/pipeline/prompts/content_pipeline/intake.md
@@ -1,0 +1,29 @@
+You are the Intake Agent in a multi-agent technical content pipeline. Your job is to read a raw user input (an idea, outline, transcript, research note, or rough draft) and produce a normalized ContentBrief that downstream agents can act on without re-asking the user clarifying questions.
+
+Read the raw input carefully and infer:
+
+- **topic**: a single sentence describing the subject of the piece.
+- **audience**: who this is for (e.g., "ML engineers building production LLM apps", "technical product managers"). Be specific.
+- **content_type**: one of `blog_post`, `linkedin_post`, `tutorial`, `readme`, `article`, `slide_outline`, `short_form_script`. Use `audience_hint` and `content_type_hint` if provided; otherwise pick the best fit.
+- **technical_depth**: one of `beginner`, `intermediate`, `advanced`.
+- **goals**: 2–4 concrete outcomes the piece should achieve (e.g., "explain X to Y so they can do Z").
+- **requested_artifacts**: which output formats the user wants. Default to `["blog_post", "linkedin_post", "x_thread"]` if unspecified.
+- **raw_input_summary**: a 1–2 sentence summary of what the user provided.
+- **key_terms** (optional): 3–8 domain terms that should remain consistent across artifacts.
+
+## User input
+
+```
+{{raw_input}}
+```
+
+## Hints (may be empty)
+
+- audience_hint: {{audience_hint}}
+- content_type_hint: {{content_type_hint}}
+
+## Reviewer feedback from prior attempt (may be empty)
+
+{{gate_feedback}}
+
+Respond with valid JSON only, matching the ContentBrief schema. Do not include prose outside the JSON. Do not invent goals the input does not support.

--- a/pipeline/prompts/content_pipeline/outline.md
+++ b/pipeline/prompts/content_pipeline/outline.md
@@ -1,0 +1,33 @@
+You are the Outline Agent in a multi-agent technical content pipeline. Your job is to convert a ContentBrief and ResearchNotes into a structured outline a drafting agent can follow without re-deriving the argument.
+
+Produce:
+
+- **title**: a sharp, concrete title appropriate to `content_type`. No generic "Introduction to ..." titles.
+- **hook**: the first 1–2 sentences. Specific, audience-aware, no clickbait.
+- **sections**: an ordered list. Requirements:
+  - Minimum 3 sections.
+  - First section must be `intro`. Last section should be `conclusion` or `cta`.
+  - At least one `explanation` or `deep_dive` section that carries the technical core.
+  - Each section: `heading`, `purpose` (one sentence describing what the section accomplishes for the reader), `key_points` (1–5 bullets the draft must cover), `section_type`.
+- **estimated_word_count**: realistic for the content_type (blog_post 800–1500, linkedin_post 200–400, tutorial 1500–3000, readme 400–1000, article 1200–2500, slide_outline 200–500, short_form_script 100–300).
+- **target_format**: matches `content_type` from the brief.
+
+Order sections logically (problem → mechanism → example → tradeoffs → conclusion is a typical shape).
+
+## ContentBrief
+
+```json
+{{brief_json}}
+```
+
+## ResearchNotes
+
+```json
+{{research_json}}
+```
+
+## Reviewer feedback from prior attempt (may be empty)
+
+{{gate_feedback}}
+
+Respond with valid JSON only, matching the ContentOutline schema. Do not include prose outside the JSON.

--- a/pipeline/prompts/content_pipeline/publishing_qa.md
+++ b/pipeline/prompts/content_pipeline/publishing_qa.md
@@ -1,0 +1,47 @@
+You are the Publishing QA Agent in a multi-agent technical content pipeline. You are the final quality gate before content ships. You read the edited long-form draft and the repurposed assets together and decide whether the package is publishable.
+
+Check for:
+
+- **missing_section**: outline sections that are absent or stubbed out.
+- **format**: broken Markdown, malformed code blocks, broken lists, mismatched math delimiters.
+- **overclaim**: statements stronger than the evidence supports ("always", "never", "the only way", "10x faster" without a source).
+- **weak_hook**: the first 1–2 sentences fail to earn attention from the brief's audience.
+- **cta**: missing or vague call-to-action where the content_type expects one.
+- **terminology**: inconsistent terminology across the long-form and the derivative assets.
+- **completeness**: derivative assets that are missing, truncated, or off-topic.
+
+For each issue produce a finding: `{category, severity, description}` where severity is one of `critical|major|minor|nit`.
+
+Then produce:
+
+- **qa_score**: integer 0–100. Subtract roughly 25 per critical, 10 per major, 3 per minor, 1 per nit, floor at 0.
+- **publishable**: boolean. False if any critical findings exist or qa_score < 60.
+- **blocking_issues**: short strings naming each blocker that prevents publication. Empty array if `publishable: true`.
+
+Be strict but fair. The content does not need to be perfect; it needs to be publishable.
+
+## EditedDraft (Markdown)
+
+```
+{{edited_markdown}}
+```
+
+## RepurposedAssets
+
+```json
+{{repurposed_json}}
+```
+
+## ContentBrief
+
+```json
+{{brief_json}}
+```
+
+## ContentOutline
+
+```json
+{{outline_json}}
+```
+
+Respond with valid JSON only, matching the PublishingQA schema. Do not include prose outside the JSON.

--- a/pipeline/prompts/content_pipeline/repurposing.md
+++ b/pipeline/prompts/content_pipeline/repurposing.md
@@ -1,0 +1,32 @@
+You are the Repurposing Agent in a multi-agent technical content pipeline. Your job is to convert the edited long-form piece into derivative assets for distinct channels. Each channel has its own voice, length, and convention — do not produce one asset and reformat it.
+
+Produce all of the following:
+
+- **linkedin_post**: 150–300 words. First line is a hook that earns the click. Plain language, one or two takeaways, ends with a soft CTA. No hashtag spam (≤3 if any). No "1/", "2/" formatting.
+- **x_thread**: an array of 5–10 tweets, each ≤280 characters. First tweet is the hook. Last tweet is the takeaway / CTA. No "1/N" prefixes; the platform threads them. Each tweet stands alone if quoted out of context.
+- **youtube_description**: 150–400 words. Opens with a 1–2 sentence summary, then a chapter-style outline with the section headings, then a short CTA. No timestamps invented.
+- **short_form_script**: 80–150 words. Designed to be read aloud in 30–60 seconds. Punchy hook in the first 5 words. One concrete payoff. No "in this video" filler.
+- **newsletter_blurb**: 80–150 words. Conversational. Tells a subscriber why the piece is worth opening, what they will learn, and one specific takeaway.
+- **readme_excerpt**: 100–250 words. Markdown. Describes what the piece covers in the voice of project documentation, suitable for embedding in a repository README's "Background" or "Further reading" section.
+
+Preserve the technical accuracy of the source. Do not introduce new claims. Do not contradict the source.
+
+## EditedDraft (Markdown)
+
+```
+{{edited_markdown}}
+```
+
+## ContentBrief
+
+```json
+{{brief_json}}
+```
+
+## ContentOutline (for headings)
+
+```json
+{{outline_json}}
+```
+
+Respond with valid JSON only, matching the RepurposedAssets schema. Do not include prose outside the JSON.

--- a/pipeline/prompts/content_pipeline/research.md
+++ b/pipeline/prompts/content_pipeline/research.md
@@ -1,0 +1,29 @@
+You are the Research Agent in a multi-agent technical content pipeline. Your job is to surface the claims a piece needs to support, the assumptions it rests on, and the open questions a careful reviewer would raise.
+
+You do **not** have live web access. Treat every factual claim that depends on external sources or current statistics as `needs_verification: true`. Treat well-known computer-science fundamentals (definitions, classical algorithms, language semantics) as `needs_verification: false` only when you are certain.
+
+For each claim provide:
+
+- **claim**: a single declarative statement.
+- **supporting_points**: 1–4 short bullets that justify the claim from first principles or named established results.
+- **needs_verification**: boolean.
+- **source_hint** (optional): a hint about where verification might come from (e.g., "original paper title", "language reference", "vendor documentation").
+
+Also produce:
+
+- **assumptions**: things the piece will take as given (audience knowledge, scope boundaries, environment).
+- **open_questions**: questions the user or a reviewer should answer before publishing.
+
+Aim for 5–10 claims, 2–5 assumptions, 2–5 open questions. Prefer specificity over breadth.
+
+## ContentBrief
+
+```json
+{{brief_json}}
+```
+
+## Reviewer feedback from prior attempt (may be empty)
+
+{{gate_feedback}}
+
+Respond with valid JSON only, matching the ResearchNotes schema. Do not include prose outside the JSON.

--- a/pipeline/prompts/content_pipeline/technical_review.md
+++ b/pipeline/prompts/content_pipeline/technical_review.md
@@ -1,0 +1,40 @@
+You are the Technical Reviewer Agent in a multi-agent technical content pipeline. You read like a careful senior engineer: you flag inaccuracies, vague claims, missing steps, and unsupported assumptions. You are not the editor — do not improve prose. Find problems.
+
+For each issue:
+
+- **severity**: one of
+  - `critical`: factually wrong, would mislead a reader, or breaks the central argument.
+  - `major`: significant gap, missing supporting detail, ambiguous step, weak technical claim.
+  - `minor`: small inaccuracy, mild overstatement, or non-blocking unclear phrasing.
+  - `nit`: stylistic or formatting issue with technical implications (e.g., misleading code formatting).
+- **location**: a section heading or a short quoted phrase from the draft that anchors the issue.
+- **description**: what is wrong and why it matters.
+- **suggested_fix** (optional): a concrete change.
+
+Also produce:
+
+- **blocking_issues_count**: integer count of `critical` issues only.
+- **overall_assessment**: 1–2 sentences summarizing the draft's technical health.
+- **requires_human** (optional): true if you flag something that genuinely needs domain expertise this pipeline cannot resolve (e.g., a vendor-specific claim that depends on the user's actual setup).
+
+Be honest. Empty `issues` is acceptable only when the draft is genuinely solid.
+
+## Draft (Markdown)
+
+```
+{{draft_markdown}}
+```
+
+## ContentBrief
+
+```json
+{{brief_json}}
+```
+
+## ResearchNotes
+
+```json
+{{research_json}}
+```
+
+Respond with valid JSON only, matching the ReviewReport schema. Do not include prose outside the JSON.

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -314,6 +314,273 @@ PLAYGROUND_CONFIG_SCHEMA = {
     "additionalProperties": False,
 }
 
+CONTENT_BRIEF_SCHEMA = {
+    "type": "object",
+    "required": [
+        "topic",
+        "audience",
+        "content_type",
+        "technical_depth",
+        "goals",
+        "requested_artifacts",
+        "raw_input_summary",
+    ],
+    "properties": {
+        "topic": {"type": "string", "minLength": 3},
+        "audience": {"type": "string", "minLength": 3},
+        "content_type": {
+            "type": "string",
+            "enum": [
+                "blog_post",
+                "linkedin_post",
+                "tutorial",
+                "readme",
+                "article",
+                "slide_outline",
+                "short_form_script",
+            ],
+        },
+        "technical_depth": {
+            "type": "string",
+            "enum": ["beginner", "intermediate", "advanced"],
+        },
+        "goals": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 3},
+            "minItems": 1,
+        },
+        "requested_artifacts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+        },
+        "raw_input_summary": {"type": "string", "minLength": 10},
+        "key_terms": {"type": "array", "items": {"type": "string"}},
+    },
+    "additionalProperties": False,
+}
+
+
+RESEARCH_NOTES_SCHEMA = {
+    "type": "object",
+    "required": ["notes", "assumptions", "open_questions"],
+    "properties": {
+        "notes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "claim",
+                    "supporting_points",
+                    "needs_verification",
+                ],
+                "properties": {
+                    "claim": {"type": "string", "minLength": 5},
+                    "supporting_points": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "needs_verification": {"type": "boolean"},
+                    "source_hint": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+            "minItems": 1,
+        },
+        "assumptions": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "open_questions": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+CONTENT_OUTLINE_SCHEMA = {
+    "type": "object",
+    "required": [
+        "title",
+        "hook",
+        "sections",
+        "estimated_word_count",
+        "target_format",
+    ],
+    "properties": {
+        "title": {"type": "string", "minLength": 5},
+        "hook": {"type": "string", "minLength": 10},
+        "sections": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["heading", "purpose", "key_points", "section_type"],
+                "properties": {
+                    "heading": {"type": "string", "minLength": 3},
+                    "purpose": {"type": "string", "minLength": 5},
+                    "key_points": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                    },
+                    "section_type": {
+                        "type": "string",
+                        "enum": [
+                            "intro",
+                            "explanation",
+                            "example",
+                            "comparison",
+                            "deep_dive",
+                            "cta",
+                            "conclusion",
+                        ],
+                    },
+                },
+                "additionalProperties": False,
+            },
+            "minItems": 3,
+        },
+        "estimated_word_count": {"type": "integer", "minimum": 100},
+        "target_format": {"type": "string", "minLength": 3},
+    },
+    "additionalProperties": False,
+}
+
+
+DRAFT_SCHEMA = {
+    "type": "object",
+    "required": ["markdown", "word_count", "sections_covered"],
+    "properties": {
+        "markdown": {"type": "string", "minLength": 200},
+        "word_count": {"type": "integer", "minimum": 50},
+        "sections_covered": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+REVIEW_REPORT_SCHEMA = {
+    "type": "object",
+    "required": ["issues", "blocking_issues_count", "overall_assessment"],
+    "properties": {
+        "issues": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["severity", "location", "description"],
+                "properties": {
+                    "severity": {
+                        "type": "string",
+                        "enum": ["critical", "major", "minor", "nit"],
+                    },
+                    "location": {"type": "string"},
+                    "description": {"type": "string", "minLength": 5},
+                    "suggested_fix": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "blocking_issues_count": {"type": "integer", "minimum": 0},
+        "overall_assessment": {"type": "string", "minLength": 5},
+        "requires_human": {"type": "boolean"},
+    },
+    "additionalProperties": False,
+}
+
+
+EDITED_DRAFT_SCHEMA = {
+    "type": "object",
+    "required": ["markdown", "word_count", "changes_made", "resolved_issues"],
+    "properties": {
+        "markdown": {"type": "string", "minLength": 200},
+        "word_count": {"type": "integer", "minimum": 50},
+        "changes_made": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "resolved_issues": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+REPURPOSED_ASSETS_SCHEMA = {
+    "type": "object",
+    "required": [
+        "linkedin_post",
+        "x_thread",
+        "youtube_description",
+        "short_form_script",
+        "newsletter_blurb",
+        "readme_excerpt",
+    ],
+    "properties": {
+        "linkedin_post": {"type": "string", "minLength": 50},
+        "x_thread": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 5},
+            "minItems": 2,
+        },
+        "youtube_description": {"type": "string", "minLength": 50},
+        "short_form_script": {"type": "string", "minLength": 30},
+        "newsletter_blurb": {"type": "string", "minLength": 30},
+        "readme_excerpt": {"type": "string", "minLength": 30},
+    },
+    "additionalProperties": False,
+}
+
+
+PUBLISHING_QA_SCHEMA = {
+    "type": "object",
+    "required": ["findings", "qa_score", "publishable", "blocking_issues"],
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["category", "severity", "description"],
+                "properties": {
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "missing_section",
+                            "format",
+                            "overclaim",
+                            "weak_hook",
+                            "cta",
+                            "terminology",
+                            "completeness",
+                        ],
+                    },
+                    "severity": {
+                        "type": "string",
+                        "enum": ["critical", "major", "minor", "nit"],
+                    },
+                    "description": {"type": "string", "minLength": 5},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "qa_score": {"type": "integer", "minimum": 0, "maximum": 100},
+        "publishable": {"type": "boolean"},
+        "blocking_issues": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+    "additionalProperties": False,
+}
+
+
 SCHEMAS = {
     "plan": PLAN_SCHEMA,
     "overview": OVERVIEW_SCHEMA,
@@ -323,4 +590,12 @@ SCHEMAS = {
     "homepage_summary": HOMEPAGE_SUMMARY_SCHEMA,
     "knowledge_graph": KNOWLEDGE_GRAPH_SCHEMA,
     "playground_config": PLAYGROUND_CONFIG_SCHEMA,
+    "content_brief": CONTENT_BRIEF_SCHEMA,
+    "research_notes": RESEARCH_NOTES_SCHEMA,
+    "content_outline": CONTENT_OUTLINE_SCHEMA,
+    "draft": DRAFT_SCHEMA,
+    "review_report": REVIEW_REPORT_SCHEMA,
+    "edited_draft": EDITED_DRAFT_SCHEMA,
+    "repurposed_assets": REPURPOSED_ASSETS_SCHEMA,
+    "publishing_qa": PUBLISHING_QA_SCHEMA,
 }

--- a/tests/test_content_agents.py
+++ b/tests/test_content_agents.py
@@ -1,0 +1,273 @@
+"""Tests for the eight content-pipeline agents.
+
+Each agent invokes :func:`pipeline.llm_client.get_provider` and
+:func:`pipeline.llm_client.generate_with_retry` through the helper on
+:class:`pipeline.agents.base.ContentAgent`. We patch those at the ``base``
+module level — exactly the same pattern other tests in this repo use for
+``api.math_tutor`` and friends.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipeline.agents.base import PipelineContext
+from pipeline.agents.drafting_agent import DraftingAgent
+from pipeline.agents.editor_agent import EditorAgent
+from pipeline.agents.intake_agent import IntakeAgent
+from pipeline.agents.outline_agent import OutlineAgent
+from pipeline.agents.publishing_qa_agent import PublishingQAAgent
+from pipeline.agents.repurposing_agent import RepurposingAgent
+from pipeline.agents.research_agent import ResearchAgent
+from pipeline.agents.technical_reviewer_agent import TechnicalReviewerAgent
+
+
+def _ctx(previous=None) -> PipelineContext:
+    return PipelineContext(
+        run_id="test-run",
+        output_dir=Path("/tmp/test-run"),
+        input={"raw_input": "Article about staged agents."},
+        previous_outputs=previous or {},
+    )
+
+
+def _mock_provider():
+    provider = MagicMock()
+    provider.model = "stub-model"
+    return provider
+
+
+class TestIntakeAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_returns_payload_on_success(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.return_value = {
+            "topic": "T",
+            "audience": "A",
+            "content_type": "blog_post",
+            "technical_depth": "intermediate",
+            "goals": ["g"],
+            "requested_artifacts": ["blog_post"],
+            "raw_input_summary": "summary text",
+        }
+        agent = IntakeAgent()
+        ctx = _ctx()
+        result = agent.run({"raw_input": "Article about staged agents."}, ctx)
+        assert result.success
+        assert result.output["topic"] == "T"
+        assert result.metadata.model == "stub-model"
+
+    def test_fails_on_empty_raw_input(self):
+        result = IntakeAgent().run({"raw_input": "   "}, _ctx())
+        assert not result.success
+        assert any("raw_input" in e for e in result.errors)
+
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_returns_failure_on_runtime_error(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.side_effect = RuntimeError("LLM exhausted retries")
+        result = IntakeAgent().run({"raw_input": "x"}, _ctx())
+        assert not result.success
+        assert any("exhausted" in e for e in result.errors)
+
+
+class TestResearchAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_requires_intake_in_context(self, mock_get_provider, mock_generate):
+        result = ResearchAgent().run({}, _ctx())
+        assert not result.success
+        mock_generate.assert_not_called()
+
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_runs_with_intake_present(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.return_value = {
+            "notes": [
+                {
+                    "claim": "X is true",
+                    "supporting_points": ["because Y"],
+                    "needs_verification": True,
+                }
+            ],
+            "assumptions": [],
+            "open_questions": [],
+        }
+        ctx = _ctx(previous={"intake": {"topic": "X"}})
+        result = ResearchAgent().run({}, ctx)
+        assert result.success
+        assert result.output["notes"][0]["needs_verification"] is True
+
+
+class TestOutlineAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_requires_intake_and_research(self, mock_get_provider, mock_generate):
+        result = OutlineAgent().run({}, _ctx(previous={"intake": {"topic": "X"}}))
+        assert not result.success
+        mock_generate.assert_not_called()
+
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_runs_with_full_context(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.return_value = {
+            "title": "T",
+            "hook": "H",
+            "sections": [
+                {
+                    "heading": "Intro",
+                    "purpose": "introduce",
+                    "key_points": ["a"],
+                    "section_type": "intro",
+                },
+                {
+                    "heading": "How",
+                    "purpose": "explain",
+                    "key_points": ["b"],
+                    "section_type": "explanation",
+                },
+                {
+                    "heading": "End",
+                    "purpose": "wrap",
+                    "key_points": ["c"],
+                    "section_type": "conclusion",
+                },
+            ],
+            "estimated_word_count": 800,
+            "target_format": "blog_post",
+        }
+        ctx = _ctx(
+            previous={
+                "intake": {"topic": "X"},
+                "research": {"notes": [], "assumptions": [], "open_questions": []},
+            }
+        )
+        result = OutlineAgent().run({}, ctx)
+        assert result.success
+        assert len(result.output["sections"]) == 3
+
+
+class TestDraftingAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_runs(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.return_value = {
+            "markdown": "## Intro\n\nbody " * 100,
+            "word_count": 200,
+            "sections_covered": ["Intro"],
+        }
+        ctx = _ctx(
+            previous={
+                "intake": {"topic": "X"},
+                "outline": {"sections": [{"heading": "Intro"}]},
+                "research": {"notes": []},
+            }
+        )
+        result = DraftingAgent().run({}, ctx)
+        assert result.success
+
+
+class TestTechnicalReviewerAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_requires_draft_markdown(self, mock_get_provider, mock_generate):
+        result = TechnicalReviewerAgent().run({}, _ctx(previous={"draft": {}}))
+        assert not result.success
+        mock_generate.assert_not_called()
+
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_runs_with_draft(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.return_value = {
+            "issues": [],
+            "blocking_issues_count": 0,
+            "overall_assessment": "fine",
+        }
+        ctx = _ctx(previous={"draft": {"markdown": "## A\n\nx"}, "intake": {}, "research": {}})
+        result = TechnicalReviewerAgent().run({}, ctx)
+        assert result.success
+
+
+class TestEditorAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_runs(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.return_value = {
+            "markdown": "## A\n\nedited body " * 50,
+            "word_count": 150,
+            "changes_made": ["tightened intro"],
+            "resolved_issues": [],
+        }
+        ctx = _ctx(
+            previous={
+                "draft": {"markdown": "## A\n\nx"},
+                "technical_review": {"issues": []},
+                "intake": {},
+            }
+        )
+        result = EditorAgent().run({}, ctx)
+        assert result.success
+
+
+class TestRepurposingAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_runs(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        payload = {
+            "linkedin_post": "x" * 80,
+            "x_thread": ["tweet one", "tweet two"],
+            "youtube_description": "y" * 80,
+            "short_form_script": "z" * 60,
+            "newsletter_blurb": "n" * 60,
+            "readme_excerpt": "r" * 60,
+        }
+        mock_generate.return_value = payload
+        ctx = _ctx(
+            previous={
+                "editor": {"markdown": "## A\n\nedited"},
+                "outline": {},
+                "intake": {},
+            }
+        )
+        result = RepurposingAgent().run({}, ctx)
+        assert result.success
+        assert "linkedin_post" in result.output
+
+    def test_fails_without_edited_markdown(self):
+        result = RepurposingAgent().run({}, _ctx(previous={"editor": {}}))
+        assert not result.success
+
+
+class TestPublishingQAAgent:
+    @patch("pipeline.agents.base.generate_with_retry")
+    @patch("pipeline.agents.base.get_provider")
+    def test_runs(self, mock_get_provider, mock_generate):
+        mock_get_provider.return_value = _mock_provider()
+        mock_generate.return_value = {
+            "findings": [],
+            "qa_score": 92,
+            "publishable": True,
+            "blocking_issues": [],
+        }
+        ctx = _ctx(
+            previous={
+                "editor": {"markdown": "## A\n\nedited"},
+                "repurposing": {},
+                "outline": {},
+                "intake": {},
+            }
+        )
+        result = PublishingQAAgent().run({}, ctx)
+        assert result.success
+        assert result.output["publishable"] is True

--- a/tests/test_content_pipeline.py
+++ b/tests/test_content_pipeline.py
@@ -1,0 +1,278 @@
+"""Tests for the ContentPipeline orchestrator.
+
+Pipeline-level tests inject a fake :class:`AgentRegistry` populated with stub
+:class:`ContentAgent` subclasses. This avoids stacking eight ``@patch``
+decorators per test and lets us script per-stage behavior precisely.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pipeline.agents.base import (
+    AgentMetadata,
+    AgentResult,
+    ContentAgent,
+    PipelineContext,
+)
+from pipeline.content_pipeline.pipeline import ContentPipeline
+from pipeline.content_pipeline.quality_gates import QualityGate, QualityGateResult
+from pipeline.content_pipeline.registry import AgentRegistry, StageDefinition
+from pipeline.content_pipeline.state import (
+    PipelineStatus,
+    StageStatus,
+    load_run,
+    save_run,
+)
+
+
+def _stub_agent_class(stage_id: str, payload: dict | None, fail: bool = False):
+    """Create a one-off ContentAgent subclass returning a fixed result."""
+
+    class _Stub(ContentAgent):
+        STAGE_ID = stage_id
+        ARTIFACT_TYPE = f"agent_{stage_id}"
+        SCHEMA_KEY = stage_id
+        PROMPT_FILE = stage_id
+
+        def __init__(self):
+            self.id = stage_id
+            self.name = f"{stage_id} (stub)"
+            self.description = ""
+            self.calls = 0
+
+        def run(self, stage_input, context: PipelineContext) -> AgentResult:
+            self.calls += 1
+            if fail:
+                return AgentResult(
+                    success=False,
+                    errors=("synthetic stub failure",),
+                    metadata=AgentMetadata(model="stub", duration_ms=1),
+                )
+            return AgentResult(
+                success=True,
+                output=payload,
+                metadata=AgentMetadata(model="stub", duration_ms=1),
+            )
+
+    return _Stub
+
+
+class _AlternatingGate(QualityGate):
+    """Fails on its first N evaluations, then passes."""
+
+    id = "alt_gate"
+    description = "fails N times then passes"
+
+    def __init__(self, stage_id: str, fail_n: int):
+        self.stage_id = stage_id
+        self._remaining = fail_n
+        self.calls = 0
+
+    def _check(self, payload, previous_outputs):
+        self.calls += 1
+        if self._remaining > 0:
+            self._remaining -= 1
+            return ["alt failure"], []
+        return [], []
+
+
+class _AlwaysFailGate(QualityGate):
+    id = "always_fail"
+    description = "always fails"
+
+    def __init__(self, stage_id: str):
+        self.stage_id = stage_id
+
+    def _check(self, payload, previous_outputs):
+        return ["fixed failure"], []
+
+
+def _minimal_registry(*overrides: StageDefinition) -> AgentRegistry:
+    """Build a 3-stage registry by default; overrides replace by stage_id."""
+    base_payloads = {
+        "intake": {"topic": "T", "audience": "A", "content_type": "blog_post", "goals": ["g"]},
+        "outline": {"title": "T"},
+        "draft": {"markdown": "x", "word_count": 1, "sections_covered": []},
+    }
+    stages = [
+        StageDefinition(
+            stage_id="intake",
+            agent=_stub_agent_class("intake", base_payloads["intake"])(),
+        ),
+        StageDefinition(
+            stage_id="outline",
+            agent=_stub_agent_class("outline", base_payloads["outline"])(),
+        ),
+        StageDefinition(
+            stage_id="draft",
+            agent=_stub_agent_class("draft", base_payloads["draft"])(),
+        ),
+    ]
+    by_id = {s.stage_id: s for s in stages}
+    for override in overrides:
+        by_id[override.stage_id] = override
+    return AgentRegistry([by_id[s.stage_id] for s in stages])
+
+
+class TestHappyPath:
+    def test_completes_and_persists(self, tmp_path: Path):
+        registry = _minimal_registry()
+        pipeline = ContentPipeline(registry=registry, output_root=tmp_path)
+        run = pipeline.run(pipeline_input={"raw_input": "hello"})
+
+        assert run.status is PipelineStatus.COMPLETED
+        assert all(s.status is StageStatus.SUCCEEDED for s in run.stages)
+        assert (tmp_path / run.run_id / "run.json").exists()
+        for stage_id in ("intake", "outline", "draft"):
+            assert (tmp_path / run.run_id / f"{stage_id}.json").exists()
+
+    def test_run_json_round_trips(self, tmp_path: Path):
+        registry = _minimal_registry()
+        pipeline = ContentPipeline(registry=registry, output_root=tmp_path)
+        run = pipeline.run(pipeline_input={"raw_input": "hello"})
+
+        loaded = load_run(run.run_id, tmp_path)
+        assert loaded.run_id == run.run_id
+        assert loaded.status is PipelineStatus.COMPLETED
+        assert [s.stage_id for s in loaded.stages] == [
+            s.stage_id for s in run.stages
+        ]
+        assert all(s.status is StageStatus.SUCCEEDED for s in loaded.stages)
+
+
+class TestHardFailure:
+    def test_required_stage_failure_marks_pipeline_failed(self, tmp_path: Path):
+        registry = _minimal_registry(
+            StageDefinition(
+                stage_id="outline",
+                agent=_stub_agent_class("outline", None, fail=True)(),
+            )
+        )
+        pipeline = ContentPipeline(registry=registry, output_root=tmp_path)
+        run = pipeline.run(pipeline_input={"raw_input": "hello"})
+
+        assert run.status is PipelineStatus.FAILED
+        statuses = {s.stage_id: s.status for s in run.stages}
+        assert statuses["intake"] is StageStatus.SUCCEEDED
+        assert statuses["outline"] is StageStatus.FAILED
+        # Downstream stage should never have run
+        assert statuses["draft"] is StageStatus.PENDING
+
+
+class TestOptionalStage:
+    def test_optional_stage_failure_is_skipped(self, tmp_path: Path):
+        registry = _minimal_registry(
+            StageDefinition(
+                stage_id="draft",
+                agent=_stub_agent_class("draft", None, fail=True)(),
+                optional=True,
+            )
+        )
+        pipeline = ContentPipeline(registry=registry, output_root=tmp_path)
+        run = pipeline.run(pipeline_input={"raw_input": "hello"})
+
+        statuses = {s.stage_id: s.status for s in run.stages}
+        assert run.status is PipelineStatus.COMPLETED
+        assert statuses["draft"] is StageStatus.SKIPPED
+
+
+class TestGateRevision:
+    def test_alternating_gate_succeeds_after_one_revision(self, tmp_path: Path):
+        gate = _AlternatingGate(stage_id="outline", fail_n=1)
+        agent = _stub_agent_class(
+            "outline", {"title": "T"}
+        )()
+        registry = _minimal_registry(
+            StageDefinition(
+                stage_id="outline",
+                agent=agent,
+                gate=gate,
+                max_revisions=1,
+            )
+        )
+        pipeline = ContentPipeline(registry=registry, output_root=tmp_path)
+        run = pipeline.run(pipeline_input={"raw_input": "hello"})
+
+        assert run.status is PipelineStatus.COMPLETED
+        outline_stage = run.stage("outline")
+        assert outline_stage.status is StageStatus.SUCCEEDED
+        assert outline_stage.retries == 1
+        assert agent.calls == 2  # one initial + one revision
+        assert gate.calls == 2
+
+    def test_budget_exhausted_marks_failed(self, tmp_path: Path):
+        gate = _AlwaysFailGate(stage_id="outline")
+        registry = _minimal_registry(
+            StageDefinition(
+                stage_id="outline",
+                agent=_stub_agent_class("outline", {"title": "T"})(),
+                gate=gate,
+                max_revisions=1,
+            )
+        )
+        pipeline = ContentPipeline(registry=registry, output_root=tmp_path)
+        run = pipeline.run(pipeline_input={"raw_input": "hello"})
+
+        assert run.status is PipelineStatus.FAILED
+        outline_stage = run.stage("outline")
+        assert outline_stage.status is StageStatus.FAILED
+        assert outline_stage.retries == 1
+
+
+class TestResume:
+    def test_resume_skips_already_succeeded_stages(self, tmp_path: Path):
+        intake_agent = _stub_agent_class(
+            "intake",
+            {
+                "topic": "T",
+                "audience": "A",
+                "content_type": "blog_post",
+                "goals": ["g"],
+            },
+        )()
+        outline_agent = _stub_agent_class("outline", {"title": "T"})()
+        draft_agent = _stub_agent_class(
+            "draft", {"markdown": "x", "word_count": 1, "sections_covered": []}
+        )()
+
+        registry = AgentRegistry(
+            [
+                StageDefinition(stage_id="intake", agent=intake_agent),
+                StageDefinition(stage_id="outline", agent=outline_agent),
+                StageDefinition(stage_id="draft", agent=draft_agent),
+            ]
+        )
+        pipeline = ContentPipeline(registry=registry, output_root=tmp_path)
+        run = pipeline.run(pipeline_input={"raw_input": "hello"})
+
+        assert intake_agent.calls == 1
+        assert outline_agent.calls == 1
+        assert draft_agent.calls == 1
+
+        # Build a fresh pipeline with fresh stub-agent instances and resume.
+        intake_agent_2 = _stub_agent_class("intake", {"topic": "T2"})()
+        outline_agent_2 = _stub_agent_class("outline", {"title": "T2"})()
+        draft_agent_2 = _stub_agent_class(
+            "draft",
+            {"markdown": "y", "word_count": 1, "sections_covered": []},
+        )()
+        registry_2 = AgentRegistry(
+            [
+                StageDefinition(stage_id="intake", agent=intake_agent_2),
+                StageDefinition(stage_id="outline", agent=outline_agent_2),
+                StageDefinition(stage_id="draft", agent=draft_agent_2),
+            ]
+        )
+        pipeline_2 = ContentPipeline(registry=registry_2, output_root=tmp_path)
+        resumed = pipeline_2.run(
+            pipeline_input={"raw_input": "hello"},
+            resume_run_id=run.run_id,
+        )
+        assert resumed.status is PipelineStatus.COMPLETED
+        # Agents from a fully-completed run are skipped; nothing is re-invoked.
+        assert intake_agent_2.calls == 0
+        assert outline_agent_2.calls == 0
+        assert draft_agent_2.calls == 0

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -1,0 +1,199 @@
+"""Tests for content-pipeline quality gates."""
+
+from __future__ import annotations
+
+from pipeline.content_pipeline.quality_gates import (
+    DraftGate,
+    FinalQAGate,
+    IntakeGate,
+    OutlineGate,
+    TechnicalReviewGate,
+)
+
+
+class TestIntakeGate:
+    def test_passes_with_complete_brief(self):
+        gate = IntakeGate()
+        result = gate.evaluate(
+            {
+                "topic": "Multi-agent orchestration",
+                "audience": "PMs",
+                "content_type": "blog_post",
+                "goals": ["explain X", "show Y"],
+            }
+        )
+        assert result.passed
+        assert result.failures == ()
+
+    def test_fails_when_audience_missing(self):
+        result = IntakeGate().evaluate(
+            {"topic": "X", "audience": "", "content_type": "blog_post", "goals": ["g"]}
+        )
+        assert not result.passed
+        assert any("audience" in f for f in result.failures)
+
+    def test_fails_when_goals_empty(self):
+        result = IntakeGate().evaluate(
+            {"topic": "X", "audience": "PMs", "content_type": "blog_post", "goals": []}
+        )
+        assert not result.passed
+        assert any("goals" in f for f in result.failures)
+
+
+class TestOutlineGate:
+    def _outline(self, **overrides):
+        base = {
+            "title": "T",
+            "hook": "H",
+            "sections": [
+                {"heading": "Intro", "section_type": "intro"},
+                {"heading": "How", "section_type": "explanation"},
+                {"heading": "End", "section_type": "conclusion"},
+            ],
+        }
+        base.update(overrides)
+        return base
+
+    def test_passes_with_three_sections_and_explanation(self):
+        result = OutlineGate().evaluate(self._outline())
+        assert result.passed
+
+    def test_fails_when_too_few_sections(self):
+        outline = self._outline(sections=[{"heading": "Only", "section_type": "intro"}])
+        result = OutlineGate().evaluate(outline)
+        assert not result.passed
+        assert any("3" in f for f in result.failures)
+
+    def test_fails_without_explanation_section(self):
+        outline = self._outline(
+            sections=[
+                {"heading": "Intro", "section_type": "intro"},
+                {"heading": "Mid", "section_type": "example"},
+                {"heading": "End", "section_type": "cta"},
+            ]
+        )
+        result = OutlineGate().evaluate(outline)
+        assert not result.passed
+        assert any("explanation" in f for f in result.failures)
+
+    def test_warns_when_first_section_is_not_intro(self):
+        outline = self._outline(
+            sections=[
+                {"heading": "Mid", "section_type": "explanation"},
+                {"heading": "More", "section_type": "deep_dive"},
+                {"heading": "End", "section_type": "conclusion"},
+            ]
+        )
+        result = OutlineGate().evaluate(outline)
+        assert result.passed
+        assert any("intro" in w.lower() for w in result.warnings)
+
+
+class TestDraftGate:
+    def _draft(self, words: int = 400, sections=None, markdown: str | None = None):
+        text = markdown or " ".join(["word"] * words)
+        return {
+            "markdown": text,
+            "word_count": len(text.split()),
+            "sections_covered": sections or ["A", "B", "C"],
+        }
+
+    def _outline(self):
+        return {
+            "outline": {
+                "sections": [
+                    {"heading": "A"},
+                    {"heading": "B"},
+                    {"heading": "C"},
+                ]
+            }
+        }
+
+    def test_passes_with_sufficient_length_and_coverage(self):
+        result = DraftGate().evaluate(self._draft(), self._outline())
+        assert result.passed
+
+    def test_fails_when_too_short(self):
+        result = DraftGate().evaluate(self._draft(words=50), self._outline())
+        assert not result.passed
+        assert any("too short" in f for f in result.failures)
+
+    def test_fails_on_placeholder_text(self):
+        markdown = "Here we go. TODO finish this section. The end."
+        draft = self._draft(markdown=markdown, sections=["A", "B", "C"])
+        # bump word count above the minimum so only the placeholder fails
+        draft["markdown"] = markdown + " " + " ".join(["word"] * 400)
+        draft["word_count"] = len(draft["markdown"].split())
+        result = DraftGate().evaluate(draft, self._outline())
+        assert not result.passed
+        assert any("placeholder" in f.lower() for f in result.failures)
+
+    def test_fails_on_low_section_coverage(self):
+        draft = self._draft(sections=["A"])
+        result = DraftGate().evaluate(draft, self._outline())
+        assert not result.passed
+        assert any("outline sections" in f for f in result.failures)
+
+
+class TestTechnicalReviewGate:
+    def test_passes_with_no_critical_issues(self):
+        result = TechnicalReviewGate().evaluate(
+            {
+                "issues": [
+                    {"severity": "minor", "location": "intro", "description": "x"}
+                ],
+                "blocking_issues_count": 0,
+                "overall_assessment": "ok",
+            }
+        )
+        assert result.passed
+
+    def test_fails_on_critical_issue(self):
+        result = TechnicalReviewGate().evaluate(
+            {
+                "issues": [
+                    {"severity": "critical", "location": "intro", "description": "wrong"}
+                ],
+                "blocking_issues_count": 1,
+                "overall_assessment": "bad",
+            }
+        )
+        assert not result.passed
+        assert any("critical" in f for f in result.failures)
+
+
+class TestFinalQAGate:
+    def test_passes_when_publishable_and_score_above_threshold(self):
+        result = FinalQAGate().evaluate(
+            {
+                "findings": [],
+                "qa_score": 90,
+                "publishable": True,
+                "blocking_issues": [],
+            }
+        )
+        assert result.passed
+
+    def test_fails_when_not_publishable(self):
+        result = FinalQAGate().evaluate(
+            {
+                "findings": [],
+                "qa_score": 50,
+                "publishable": False,
+                "blocking_issues": ["weak hook"],
+            }
+        )
+        assert not result.passed
+        assert any("weak hook" in f for f in result.failures)
+
+    def test_fails_on_low_score_even_if_publishable_flag_true(self):
+        result = FinalQAGate().evaluate(
+            {
+                "findings": [],
+                "qa_score": 40,
+                "publishable": True,
+                "blocking_issues": [],
+            }
+        )
+        assert not result.passed
+        assert any("score" in f.lower() for f in result.failures)


### PR DESCRIPTION
Layers a staged pipeline (intake, research, outline, draft, technical
review, edit, repurposing, publishing QA) on top of the existing
LLMProvider and generate_with_retry infrastructure. Each stage writes a
typed JSON artifact, quality gates between stages can trigger one
revision pass, and interrupted runs resume by run id.

- pipeline/content_pipeline/: orchestrator, registry, gates, run state
- pipeline/agents/: 8 ContentAgent subclasses + base ABC
- pipeline/prompts/content_pipeline/: 8 prompt templates ({{var}} style)
- pipeline/schemas.py: 8 new schemas registered in SCHEMAS
- pipeline/config.json: 8 new artifact_provider_map keys
- examples/run_content_pipeline.py: CLI with --dry-run stub mode
- tests/test_quality_gates.py, test_content_agents.py, test_content_pipeline.py:
  37 tests covering happy path, hard failure, optional skip, gate revision,
  budget exhaustion, and resume-from-run_id
- docs/content-pipeline-orchestration.md: architecture, contracts, how to
  add a new agent